### PR TITLE
refactor: shared app layer + Match ROM prefix caching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,17 @@ CMSIS_CORE_DIR   = CMSIS/core
 CMSIS_DEVICE_DIR = CMSIS/device
 
 # Define the C source files, assembly source file, linker script, and preprocessor definitions
-SRC = $(CMSIS_DEVICE_DIR)/system_stm32f1xx.c src/$(APP).c src/ds18b20.c
+SRC = $(CMSIS_DEVICE_DIR)/system_stm32f1xx.c src/$(APP).c src/ds18b20.c src/app.c
 ASM = $(CMSIS_DEVICE_DIR)/startup_stm32f103xb.s
 LDS = STM32F103XB_FLASH.ld
 MCU = -mcpu=cortex-m3 -mthumb
 DEF = -DSTM32F103xB
 INC = -I. -Iinc -I$(CMSIS_CORE_DIR) -I$(CMSIS_DEVICE_DIR)
+
+# Per-app USART1 TX ring buffer size (power of two), overrides the app.h default
+UART_TX_SIZE_demo  = 128
+UART_TX_SIZE_demo2 = 256
+DEF += -DUART_TX_BUF_SIZE=$(UART_TX_SIZE_$(APP))
 
 # Define additional preprocessor definitions based on conditional variables
 # make HSI_8MHZ=1  →  -DHSI_8MHZ=1  (run on HSI 8MHz instead of HSE+PLL 72MHz)

--- a/inc/app.h
+++ b/inc/app.h
@@ -1,0 +1,83 @@
+/**
+ * @file app.h
+ * @brief Shared application layer for the DS18B20 example projects
+ * 
+ * Bundles everything an example application needs: the DS18B20 driver API
+ * plus a small platform layer (system clock, USART1 TX ring buffer, busy
+ * LED) behind a single header, so the demos stay short and readable.
+ * 
+ * Usage:
+ * 1. #include "app.h" (defines UART_TX_BUF_SIZE, or -D on the command line)
+ * 2. Call app_init() once at startup
+ * 3. Use uart_write_*() to enqueue strings to the lossless TX ring buffer
+ * 4. Call uart_poll_tx() periodically to feed the UART from the buffer
+ */
+
+#ifndef APP_H
+#define APP_H
+
+#include "ds18b20.h"
+#include <stdint.h>
+
+#ifndef UART_TX_BUF_SIZE
+#define UART_TX_BUF_SIZE 128u /**< Default TX ring buffer size (power of two) */
+#endif
+
+#if (UART_TX_BUF_SIZE & (UART_TX_BUF_SIZE - 1u)) != 0
+#error "UART_TX_BUF_SIZE must be a power of two (e.g., 32, 64, 128, 256)."
+#endif
+
+/** Mask for ring buffer index wrapping (power of two optimization) */
+#define UART_TX_IDX_MASK (UART_TX_BUF_SIZE - 1u)
+/** UART baud rate register value with rounding for accuracy */
+#define USART_BRR_CALC(PCLK, BAUD) (((PCLK) + ((BAUD) / 2)) / (BAUD))
+
+/**
+ * @brief Initialize system clock, USART1 TX and the busy LED GPIO
+ * @note One call instead of configure_system_clock() + hardware_init()
+ */
+void app_init(void);
+
+/**
+ * @brief Advance USART1 transmission by at most one byte (non-blocking)
+ * @note Must be called periodically to feed the UART from the ring buffer
+ */
+void uart_poll_tx(void);
+
+/**
+ * @brief Enqueue a single byte into the USART1 TX ring buffer (lossless)
+ * @param[in] b Byte to enqueue
+ * @note Blocks only while the buffer is full, polling uart_poll_tx() to make
+ *       room - a byte is never dropped
+ */
+void uart_tx_enqueue_byte(uint8_t b);
+
+/**
+ * @brief Enqueue a null-terminated string (lossless)
+ * @param[in] s Null-terminated string to enqueue
+ * @return Number of characters enqueued
+ */
+int uart_write_str(const char* s);
+
+/**
+ * @brief Enqueue an integer as a decimal string (lossless)
+ * @param[in] value Integer value to enqueue (full 32-bit range supported)
+ * @return Number of characters enqueued
+ */
+int uart_write_int(int value);
+
+/**
+ * @brief Enqueue a byte as two uppercase hexadecimal digits
+ * @param[in] b Byte to enqueue
+ * @return Number of characters enqueued (always 2)
+ */
+int uart_write_hex(uint8_t b);
+
+/**
+ * @brief Blocking drain of the USART1 TX ring buffer
+ * @note Waits until every enqueued byte has been shifted out (TC set).
+ *       Use once at startup so banners are never truncated.
+ */
+void uart_tx_flush(void);
+
+#endif // APP_H

--- a/src/app.c
+++ b/src/app.c
@@ -1,0 +1,207 @@
+/**
+ * @file app.c
+ * @brief Shared application layer implementation (UART TX, system clock, LED)
+ */
+
+#include "app.h"
+#include "stm32f1xx.h"
+
+// ======== USART1 TX ring buffer ========
+static uint8_t uart_tx_head = 0; // write index - points to next free slot
+static uint8_t uart_tx_tail = 0; // read index - points to oldest data
+static uint8_t uart_tx_buf[UART_TX_BUF_SIZE]; // circular buffer for UART transmission
+
+/**
+ * @brief Advance UART transmission by at most one byte (non-blocking)
+ * @note Must be called periodically to feed UART hardware from the buffer
+ */
+void uart_poll_tx(void) {
+    // Check if UART is ready to transmit (TXE flag set) and buffer not empty
+    if ((USART1->SR & USART_SR_TXE) && (uart_tx_tail != uart_tx_head)) {
+        // Get byte from buffer at tail position
+        uint8_t b = uart_tx_buf[uart_tx_tail];
+        // Advance tail pointer with wrap-around
+        uart_tx_tail = (uint8_t)((uart_tx_tail + 1u) & UART_TX_IDX_MASK);
+        // Write byte to UART data register for transmission
+        USART1->DR = b;
+    }
+}
+
+/**
+ * @brief Enqueue a single byte into the UART transmit buffer (lossless)
+ * @param[in] b Byte to enqueue
+ * @note Blocks only while the buffer is full, polling uart_poll_tx() to make
+ *       room - a byte is never dropped
+ */
+void uart_tx_enqueue_byte(uint8_t b) {
+    for (;;) {
+        uint8_t head = uart_tx_head;
+        // Calculate next head position with wrap-around using power-of-two mask
+        uint8_t next = (uint8_t)((head + 1u) & UART_TX_IDX_MASK);
+        if (next != uart_tx_tail) { // Room is available
+            uart_tx_buf[head] = b; // Store byte at current head position
+            uart_tx_head = next; // Update head pointer
+            return;
+        }
+        uart_poll_tx(); // Make room by feeding one byte to the UART
+    }
+}
+
+/**
+ * @brief Enqueue an entire null-terminated string (lossless)
+ * @param[in] s Null-terminated string to enqueue
+ * @return Number of characters enqueued
+ */
+int uart_write_str(const char* s) {
+    const char* start = s;
+    while (*s) {
+        uart_tx_enqueue_byte((uint8_t)*s);
+        s++;
+    }
+    return (int)(s - start);
+}
+
+/**
+ * @brief Convert integer to string and enqueue for UART transmission
+ * @param[in] value Integer value to convert and transmit
+ * @return Number of characters enqueued
+ * @note Buffer holds 12 chars, enough for the full int32 range (-2147483648)
+ */
+int uart_write_int(int value) {
+    char buf[12]; // enough for -2147483648 and '\0'
+    char* p = buf + sizeof(buf) - 1;
+    *p = '\0';
+
+    if (value == 0) { // Special case for zero
+        *(--p) = '0';
+    } else {
+        int is_negative = 0;
+        unsigned int uvalue;
+
+        if (value < 0) { // Handle negative numbers
+            is_negative = 1;
+            uvalue = (unsigned int)-(value + 1) + 1;
+        } else {
+            uvalue = (unsigned int)value;
+        }
+
+        do { // Convert digits from least significant to most significant
+            *(--p) = '0' + (uvalue % 10);
+            uvalue /= 10;
+        } while (uvalue);
+
+        if (is_negative) *(--p) = '-'; // Add negative sign if needed
+    }
+    return uart_write_str(p);
+}
+
+/**
+ * @brief Enqueue one byte as two uppercase hexadecimal digits
+ * @param[in] b Byte to convert and transmit
+ * @return Number of characters enqueued (always 2)
+ */
+int uart_write_hex(uint8_t b) {
+    static const char hex[] = "0123456789ABCDEF";
+    uart_tx_enqueue_byte((uint8_t)hex[(b >> 4) & 0x0F]);
+    uart_tx_enqueue_byte((uint8_t)hex[b & 0x0F]);
+    return 2;
+}
+
+/**
+ * @brief Blocking drain of the UART TX ring buffer
+ * @note Waits until every enqueued byte has been shifted out (TC set).
+ *       Call once at startup so the banner is never truncated.
+ */
+void uart_tx_flush(void) {
+    while (uart_tx_tail != uart_tx_head) {
+        uart_poll_tx();
+    }
+    while (!(USART1->SR & USART_SR_TC)) {
+        ;
+    }
+}
+
+/**
+ * @brief Configure system clock (72MHz via HSE+PLL, or skip for HSI 8MHz)
+ */
+__STATIC_FORCEINLINE void configure_system_clock(void) {
+#ifndef HSI_8MHZ
+    // Enable HSI and HSE oscillators
+    RCC->CR = RCC_CR_HSION | RCC_CR_HSEON;
+    // Wait for HSE to stabilize - HSERDY is the hardware stabilization
+    // indicator, so no fixed delay is required
+    while (!(RCC->CR & RCC_CR_HSERDY))
+        ;
+    // Configure PLL: HSE source, multiply by 9, APB1 prescaler /2
+    RCC->CFGR = RCC_CFGR_PLLSRC | RCC_CFGR_PLLMULL9 | RCC_CFGR_PPRE1_DIV2;
+    // Enable PLL only after HSE is confirmed stable, so the PLL locks on a
+    // valid clock (per RM0008: HSE must be ready before enabling the PLL)
+    RCC->CR |= RCC_CR_PLLON;
+    // Wait for the PLL to lock
+    while (!(RCC->CR & RCC_CR_PLLRDY))
+        ;
+    // Configure flash latency for 72MHz operation
+    FLASH->ACR = FLASH_ACR_PRFTBE | FLASH_ACR_LATENCY_2;
+    // Switch system clock to PLL
+    RCC->CFGR = RCC_CFGR_PLLSRC | RCC_CFGR_PLLMULL9 | RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_SW_PLL;
+    // Wait for system clock switch to PLL
+    while ((RCC->CFGR & RCC_CFGR_SWS_PLL) != RCC_CFGR_SWS_PLL)
+        ;
+    // Disable HSI oscillator
+    RCC->CR &= ~RCC_CR_HSION;
+#endif
+    // HSI_8MHZ: MCU already runs on HSI 8MHz after reset — nothing to configure
+}
+
+/**
+ * @brief Initialize microcontroller peripherals for UART communication and LED control
+ */
+__STATIC_FORCEINLINE void hardware_init(void) {
+
+    // Enable clock for GPIOA, USART1, and GPIOC peripherals
+    RCC->APB2ENR |= (RCC_APB2ENR_IOPAEN | RCC_APB2ENR_USART1EN | RCC_APB2ENR_IOPCEN);
+
+    // Configure PA9 as alternate function push-pull output, 2MHz speed
+    // Clear existing configuration bits
+    GPIOA->CRH &= ~(GPIO_CRH_MODE9 | GPIO_CRH_CNF9);
+    // Set alternate function push-pull output mode, 2MHz speed
+    GPIOA->CRH |= (GPIO_CRH_MODE9_1 | GPIO_CRH_CNF9_1);
+
+    // Configure PC13 as general purpose output, 2MHz speed for LED control
+    GPIOC->CRH &= ~(GPIO_CRH_MODE13 | GPIO_CRH_CNF13);
+    GPIOC->CRH |= GPIO_CRH_MODE13_1;
+
+    // Configure USART1: 115200 baud, 8 data bits, no parity, 1 stop bit, TX only
+#ifdef HSI_8MHZ
+    USART1->BRR = USART_BRR_CALC(8000000, 115200); // PCLK2=8MHz
+#else
+    USART1->BRR = USART_BRR_CALC(72000000, 115200); // PCLK2=72MHz
+#endif
+    USART1->CR1 = USART_CR1_TE | USART_CR1_UE; // Enable USART1; TX enable only
+}
+
+/**
+ * @brief Initialize system clock, USART1 TX and the busy LED GPIO
+ */
+void app_init(void) {
+    configure_system_clock();
+    hardware_init();
+}
+
+/**
+ * @brief Busy indicator - toggles LED during measurement
+ * @param[in] action 0 = idle, non-zero = busy
+ * @note Non-blocking LED control using atomic BSRR register operations.
+ *       Strong definition overrides the weak one in the DS18B20 driver.
+ */
+void ds18b20_busy(unsigned action) {
+    if (action) {
+        // Turn LED on (PC13 low due to pull-up LED configuration)
+        // BSRR BR register: atomic bit reset operation
+        GPIOC->BSRR = GPIO_BSRR_BR13;
+    } else {
+        // Turn LED off (PC13 high)
+        // BSRR BS register: atomic bit set operation
+        GPIOC->BSRR = GPIO_BSRR_BS13;
+    }
+}

--- a/src/demo.c
+++ b/src/demo.c
@@ -1,186 +1,12 @@
-#include "ds18b20.h"
-#include "stm32f1xx.h"
-
-// ======== Config: printing buffer size (power of two) ========
-#ifndef UART_TX_BUF_SIZE
-#define UART_TX_BUF_SIZE 128u // set to 128 or 256 as desired
-#endif
-
-// Validate that buffer size is a power of two for efficient masking operations
-#if (UART_TX_BUF_SIZE & (UART_TX_BUF_SIZE - 1u)) != 0
-#error "UART_TX_BUF_SIZE must be a power of two (e.g., 32, 64, 128, 256)."
-#endif
-
-// Create mask for buffer index wrapping (power of two optimization)
-#define UART_TX_IDX_MASK (UART_TX_BUF_SIZE - 1u)
-// Calculate baud rate register value with rounding for accuracy
-#define USART_BRR_CALC(PCLK, BAUD) (((PCLK) + ((BAUD) / 2)) / (BAUD))
-
-// ======== USART1 TX ring buffer ========
-static uint8_t uart_tx_head = 0; // write index - points to next free slot
-static uint8_t uart_tx_tail = 0; // read index - points to oldest data
-static uint8_t uart_tx_buf[UART_TX_BUF_SIZE]; // circular buffer for UART transmission
-
 /**
- * @brief Non-blocking function to enqueue a single byte into the UART transmit buffer
- * @param[in] b Byte to enqueue
- * @return 1 on success, 0 if buffer full
- * @note Returns immediately without blocking
+ * @file demo.c
+ * @brief Single-sensor example: one DS18B20, Skip ROM addressing
+ * 
+ * Demonstrates the basic measurement flow of the non-blocking driver.
+ * The shared platform layer (app.h/app.c) hides the UART and clock setup.
  */
-__STATIC_FORCEINLINE int uart_tx_enqueue_byte(uint8_t b) {
-    uint8_t head = uart_tx_head;
-    // Calculate next head position with wrap-around using power-of-two mask
-    uint8_t next = (uint8_t)((head + 1u) & UART_TX_IDX_MASK);
-    if (next == uart_tx_tail) { // Check if buffer is full
-        return 0; // Buffer full - non-blocking return
-    }
 
-    uart_tx_buf[head] = b; // Store byte at current head position
-    uart_tx_head = next; // Atomically update head pointer
-    return 1; // Success
-}
-
-/**
- * @brief Non-blocking function to enqueue entire null-terminated string into UART transmit buffer
- * @param[in] s Null-terminated string to enqueue
- * @return Number of characters successfully enqueued
- */
-__STATIC_FORCEINLINE int uart_write_str(const char* s) {
-    const char* start = s;
-    // Process each character until null terminator
-    while (*s) {
-        // Try to enqueue current character, break on buffer full (non-blocking)
-        if (!uart_tx_enqueue_byte((uint8_t)*s)) break;
-        s++;
-    }
-    // Return count of successfully enqueued characters
-    return (int)(s - start);
-}
-
-/**
- * @brief Non-blocking function to advance UART transmission by at most one byte
- * @note Must be called periodically to feed UART hardware from buffer
- * @note Returns immediately without blocking
- */
-__STATIC_FORCEINLINE void uart_poll_tx(void) {
-    // Check if UART is ready to transmit (TXE flag set) and buffer not empty
-    if ((USART1->SR & USART_SR_TXE) && (uart_tx_tail != uart_tx_head)) {
-        // Get byte from buffer at tail position
-        uint8_t b = uart_tx_buf[uart_tx_tail];
-        // Advance tail pointer with wrap-around
-        uart_tx_tail = (uint8_t)((uart_tx_tail + 1u) & UART_TX_IDX_MASK);
-        // Write byte to UART data register for transmission
-        USART1->DR = b;
-    }
-}
-
-/**
- * @brief Configure system clock (72MHz via HSE+PLL, or skip for HSI 8MHz)
- */
-__STATIC_FORCEINLINE void configure_system_clock(void) {
-#ifndef HSI_8MHZ
-    // Enable HSI and HSE oscillators
-    RCC->CR = RCC_CR_HSION | RCC_CR_HSEON;
-    // Wait for HSE to stabilize - HSERDY is the hardware stabilization
-    // indicator, so no fixed delay is required
-    while (!(RCC->CR & RCC_CR_HSERDY))
-        ;
-    // Configure PLL: HSE source, multiply by 9, APB1 prescaler /2
-    RCC->CFGR = RCC_CFGR_PLLSRC | RCC_CFGR_PLLMULL9 | RCC_CFGR_PPRE1_DIV2;
-    // Enable PLL only after HSE is confirmed stable, so the PLL locks on a
-    // valid clock (per RM0008: HSE must be ready before enabling the PLL)
-    RCC->CR |= RCC_CR_PLLON;
-    // Wait for the PLL to lock
-    while (!(RCC->CR & RCC_CR_PLLRDY))
-        ;
-    // Configure flash latency for 72MHz operation
-    FLASH->ACR = FLASH_ACR_PRFTBE | FLASH_ACR_LATENCY_2;
-    // Switch system clock to PLL
-    RCC->CFGR = RCC_CFGR_PLLSRC | RCC_CFGR_PLLMULL9 | RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_SW_PLL;
-    // Wait for system clock switch to PLL
-    while ((RCC->CFGR & RCC_CFGR_SWS_PLL) != RCC_CFGR_SWS_PLL)
-        ;
-    // Disable HSI oscillator
-    RCC->CR &= ~RCC_CR_HSION;
-#endif
-    // HSI_8MHZ: MCU already runs on HSI 8MHz after reset — nothing to configure
-}
-
-/**
- * @brief Initialize microcontroller peripherals for UART communication and LED control
- */
-__STATIC_FORCEINLINE void hardware_init(void) {
-
-    // Enable clock for GPIOA, USART1, and GPIOC peripherals
-    RCC->APB2ENR |= (RCC_APB2ENR_IOPAEN | RCC_APB2ENR_USART1EN | RCC_APB2ENR_IOPCEN);
-
-    // Configure PA9 as alternate function push-pull output, 2MHz speed
-    // Clear existing configuration bits
-    GPIOA->CRH &= ~(GPIO_CRH_MODE9 | GPIO_CRH_CNF9);
-    // Set alternate function push-pull output mode, 2MHz speed
-    GPIOA->CRH |= (GPIO_CRH_MODE9_1 | GPIO_CRH_CNF9_1);
-
-    // Configure PC13 as general purpose output, 2MHz speed for LED control
-    GPIOC->CRH &= ~(GPIO_CRH_MODE13 | GPIO_CRH_CNF13);
-    GPIOC->CRH |= GPIO_CRH_MODE13_1;
-
-    // Configure USART1: 115200 baud, 8 data bits, no parity, 1 stop bit, TX only
-#ifdef HSI_8MHZ
-    USART1->BRR = USART_BRR_CALC(8000000, 115200); // PCLK2=8MHz
-#else
-    USART1->BRR = USART_BRR_CALC(72000000, 115200); // PCLK2=72MHz
-#endif
-    USART1->CR1 = USART_CR1_TE | USART_CR1_UE; // Enable USART1; TX enable only
-}
-
-/**
- * @brief Busy indicator - toggles LED during measurement
- * @param[in] action 0 = idle, non-zero = busy
- * @note Non-blocking LED control using atomic BSRR register operations
- */
-void ds18b20_busy(unsigned action) {
-    if (action) {
-        // Turn LED on (PC13 low due to pull-up LED configuration)
-        // BSRR BR register: atomic bit reset operation
-        GPIOC->BSRR = GPIO_BSRR_BR13;
-    } else {
-        // Turn LED off (PC13 high)
-        // BSRR BS register: atomic bit set operation
-        GPIOC->BSRR = GPIO_BSRR_BS13;
-    }
-}
-
-/**
- * @brief Convert integer to string and enqueue for UART transmission
- * @param[in] value Integer value to convert and transmit
- */
-__STATIC_FORCEINLINE void uart_write_int(int value) {
-    char buf[7]; // enough for -32768 and '\0'
-    char* p = buf + sizeof(buf) - 1;
-    *p = '\0';
-
-    if (value == 0) { // Special case for zero
-        *(--p) = '0';
-    } else {
-        int is_negative = 0;
-        unsigned int uvalue;
-
-        if (value < 0) { // Handle negative numbers
-            is_negative = 1;
-            uvalue = (unsigned int)-(value + 1) + 1;
-        } else {
-            uvalue = value;
-        }
-
-        do { // Convert digits from least significant to most significant
-            *(--p) = '0' + (uvalue % 10);
-            uvalue /= 10;
-        } while (uvalue);
-
-        if (is_negative) *(--p) = '-'; // Add negative sign if needed
-    }
-    (void)uart_write_str(p); // best-effort enqueue to UART buffer
-}
+#include "app.h"
 
 /**
  * @brief Weak implementation for DS18B20 measurement completion callback - handles result display
@@ -216,10 +42,11 @@ void ds18b20_complete(int16_t temp) {
  */
 int main(void) {
 
-    configure_system_clock(); // Configure system clock for MCU
+    app_init(); // System clock, UART and LED GPIO - single setup call
 
-    hardware_init(); // Initialize hardware peripherals (non-blocking)
-    uart_write_str("DS18B20 demo starting...\r\n"); // Enqueue startup message to UART buffer
+    uart_write_str("DS18B20 demo starting...\r\n"); // Enqueue startup message
+    uart_tx_flush(); // Block until the banner is fully transmitted
+
     ds18b20_init(); // Initialize DS18B20 driver (non-blocking)
 
     for (;;) { // Main event loop (non-blocking, cooperative multitasking)

--- a/src/demo2.c
+++ b/src/demo2.c
@@ -1,10 +1,14 @@
-#include "ds18b20.h"
-#include "stm32f1xx.h"
+/**
+ * @file demo2.c
+ * @brief Multi-sensor example: startup bus scan + round-robin polling
+ * 
+ * Demonstrates ds18b20_search_devices() to enumerate every DS18B20 on the
+ * bus, then ds18b20_select() to measure each sensor in turn. The shared
+ * platform layer (app.h/app.c) hides the UART and clock setup.
+ */
 
-// ======== Config: printing buffer size (power of two) ========
-#ifndef UART_TX_BUF_SIZE
-#define UART_TX_BUF_SIZE 256u // set to 128 or 256 as desired
-#endif
+#include "app.h"
+
 // ======== Config: maximum devices reported by the startup bus scan ========
 #ifndef DS18B20_SEARCH_MAX_DEVICES
 #define DS18B20_SEARCH_MAX_DEVICES 8u
@@ -14,209 +18,6 @@
 static uint8_t found_roms[DS18B20_SEARCH_MAX_DEVICES][8]; // ROMs found at startup
 static uint8_t found_count = 0; // how many devices were found
 static uint8_t select_index = 0; // index of the currently selected device
-
-// Validate that buffer size is a power of two for efficient masking operations
-#if (UART_TX_BUF_SIZE & (UART_TX_BUF_SIZE - 1u)) != 0
-#error "UART_TX_BUF_SIZE must be a power of two (e.g., 32, 64, 128, 256)."
-#endif
-
-// Create mask for buffer index wrapping (power of two optimization)
-#define UART_TX_IDX_MASK (UART_TX_BUF_SIZE - 1u)
-// Calculate baud rate register value with rounding for accuracy
-#define USART_BRR_CALC(PCLK, BAUD) (((PCLK) + ((BAUD) / 2)) / (BAUD))
-
-// ======== USART1 TX ring buffer ========
-static uint8_t uart_tx_head = 0; // write index - points to next free slot
-static uint8_t uart_tx_tail = 0; // read index - points to oldest data
-static uint8_t uart_tx_buf[UART_TX_BUF_SIZE]; // circular buffer for UART transmission
-
-/**
- * @brief Advance UART transmission by at most one byte (non-blocking)
- * @note Must be called periodically to feed UART hardware from the buffer
- */
-__STATIC_FORCEINLINE void uart_poll_tx(void) {
-    // Check if UART is ready to transmit (TXE flag set) and buffer not empty
-    if ((USART1->SR & USART_SR_TXE) && (uart_tx_tail != uart_tx_head)) {
-        // Get byte from buffer at tail position
-        uint8_t b = uart_tx_buf[uart_tx_tail];
-        // Advance tail pointer with wrap-around
-        uart_tx_tail = (uint8_t)((uart_tx_tail + 1u) & UART_TX_IDX_MASK);
-        // Write byte to UART data register for transmission
-        USART1->DR = b;
-    }
-}
-
-/**
- * @brief Enqueue a single byte into the UART transmit buffer (lossless)
- * @param[in] b Byte to enqueue
- * @note Blocks only while the buffer is full, polling uart_poll_tx() to make
- *       room - a byte is never dropped. With a 256-byte buffer the worst-case
- *       stall at 115200 baud is ~23 ms.
- */
-__STATIC_FORCEINLINE void uart_tx_enqueue_byte(uint8_t b) {
-    for (;;) {
-        uint8_t head = uart_tx_head;
-        // Calculate next head position with wrap-around using power-of-two mask
-        uint8_t next = (uint8_t)((head + 1u) & UART_TX_IDX_MASK);
-        if (next != uart_tx_tail) { // Room is available
-            uart_tx_buf[head] = b; // Store byte at current head position
-            uart_tx_head = next; // Update head pointer
-            return;
-        }
-        uart_poll_tx(); // Make room by feeding one byte to the UART
-    }
-}
-
-/**
- * @brief Enqueue an entire null-terminated string (lossless)
- * @param[in] s Null-terminated string to enqueue
- * @return Number of characters enqueued
- */
-__STATIC_FORCEINLINE int uart_write_str(const char* s) {
-    const char* start = s;
-    while (*s) {
-        uart_tx_enqueue_byte((uint8_t)*s);
-        s++;
-    }
-    return (int)(s - start);
-}
-
-/**
- * @brief Blocking drain of the UART TX ring buffer
- * @note Waits until every enqueued byte has been shifted out (TC set).
- *       Call once at startup after the bus-scan report so the banner is
- *       never truncated, regardless of buffer size vs. message length.
- *       At 115200 baud a 256-byte buffer drains in ~23 ms.
- */
-__STATIC_FORCEINLINE void uart_tx_flush(void) {
-    while (uart_tx_tail != uart_tx_head) {
-        uart_poll_tx();
-    }
-    while (!(USART1->SR & USART_SR_TC)) {
-        ;
-    }
-}
-
-/**
- * @brief Configure system clock (72MHz via HSE+PLL, or skip for HSI 8MHz)
- */
-__STATIC_FORCEINLINE void configure_system_clock(void) {
-#ifndef HSI_8MHZ
-    // Enable HSI and HSE oscillators
-    RCC->CR = RCC_CR_HSION | RCC_CR_HSEON;
-    // Wait for HSE to stabilize - HSERDY is the hardware stabilization
-    // indicator, so no fixed delay is required
-    while (!(RCC->CR & RCC_CR_HSERDY))
-        ;
-    // Configure PLL: HSE source, multiply by 9, APB1 prescaler /2
-    RCC->CFGR = RCC_CFGR_PLLSRC | RCC_CFGR_PLLMULL9 | RCC_CFGR_PPRE1_DIV2;
-    // Enable PLL only after HSE is confirmed stable, so the PLL locks on a
-    // valid clock (per RM0008: HSE must be ready before enabling the PLL)
-    RCC->CR |= RCC_CR_PLLON;
-    // Wait for the PLL to lock
-    while (!(RCC->CR & RCC_CR_PLLRDY))
-        ;
-    // Configure flash latency for 72MHz operation
-    FLASH->ACR = FLASH_ACR_PRFTBE | FLASH_ACR_LATENCY_2;
-    // Switch system clock to PLL
-    RCC->CFGR = RCC_CFGR_PLLSRC | RCC_CFGR_PLLMULL9 | RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_SW_PLL;
-    // Wait for system clock switch to PLL
-    while ((RCC->CFGR & RCC_CFGR_SWS_PLL) != RCC_CFGR_SWS_PLL)
-        ;
-    // Disable HSI oscillator
-    RCC->CR &= ~RCC_CR_HSION;
-#endif
-    // HSI_8MHZ: MCU already runs on HSI 8MHz after reset — nothing to configure
-}
-
-/**
- * @brief Initialize microcontroller peripherals for UART communication and LED control
- */
-__STATIC_FORCEINLINE void hardware_init(void) {
-
-    // Enable clock for GPIOA, USART1, and GPIOC peripherals
-    RCC->APB2ENR |= (RCC_APB2ENR_IOPAEN | RCC_APB2ENR_USART1EN | RCC_APB2ENR_IOPCEN);
-
-    // Configure PA9 as alternate function push-pull output, 2MHz speed
-    // Clear existing configuration bits
-    GPIOA->CRH &= ~(GPIO_CRH_MODE9 | GPIO_CRH_CNF9);
-    // Set alternate function push-pull output mode, 2MHz speed
-    GPIOA->CRH |= (GPIO_CRH_MODE9_1 | GPIO_CRH_CNF9_1);
-
-    // Configure PC13 as general purpose output, 2MHz speed for LED control
-    GPIOC->CRH &= ~(GPIO_CRH_MODE13 | GPIO_CRH_CNF13);
-    GPIOC->CRH |= GPIO_CRH_MODE13_1;
-
-    // Configure USART1: 115200 baud, 8 data bits, no parity, 1 stop bit, TX only
-#ifdef HSI_8MHZ
-    USART1->BRR = USART_BRR_CALC(8000000, 115200); // PCLK2=8MHz
-#else
-    USART1->BRR = USART_BRR_CALC(72000000, 115200); // PCLK2=72MHz
-#endif
-    USART1->CR1 = USART_CR1_TE | USART_CR1_UE; // Enable USART1; TX enable only
-}
-
-/**
- * @brief Busy indicator - toggles LED during measurement
- * @param[in] action 0 = idle, non-zero = busy
- * @note Non-blocking LED control using atomic BSRR register operations
- */
-void ds18b20_busy(unsigned action) {
-    if (action) {
-        // Turn LED on (PC13 low due to pull-up LED configuration)
-        // BSRR BR register: atomic bit reset operation
-        GPIOC->BSRR = GPIO_BSRR_BR13;
-    } else {
-        // Turn LED off (PC13 high)
-        // BSRR BS register: atomic bit set operation
-        GPIOC->BSRR = GPIO_BSRR_BS13;
-    }
-}
-
-/**
- * @brief Convert integer to string and enqueue for UART transmission
- * @param[in] value Integer value to convert and transmit
- * @return Number of characters enqueued
- */
-__STATIC_FORCEINLINE int uart_write_int(int value) {
-    char buf[7]; // enough for -32768 and '\0'
-    char* p = buf + sizeof(buf) - 1;
-    *p = '\0';
-
-    if (value == 0) { // Special case for zero
-        *(--p) = '0';
-    } else {
-        int is_negative = 0;
-        unsigned int uvalue;
-
-        if (value < 0) { // Handle negative numbers
-            is_negative = 1;
-            uvalue = (unsigned int)-(value + 1) + 1;
-        } else {
-            uvalue = value;
-        }
-
-        do { // Convert digits from least significant to most significant
-            *(--p) = '0' + (uvalue % 10);
-            uvalue /= 10;
-        } while (uvalue);
-
-        if (is_negative) *(--p) = '-'; // Add negative sign if needed
-    }
-    return uart_write_str(p);
-}
-
-/**
- * @brief Enqueue one byte as two uppercase hexadecimal digits
- * @param[in] b Byte to convert and transmit
- * @return Number of characters enqueued (always 2)
- */
-__STATIC_FORCEINLINE int uart_write_hex(uint8_t b) {
-    static const char hex[] = "0123456789ABCDEF";
-    uart_tx_enqueue_byte((uint8_t)hex[(b >> 4) & 0x0F]);
-    uart_tx_enqueue_byte((uint8_t)hex[b & 0x0F]);
-    return 2;
-}
 
 /**
  * @brief Device search callback - stores the ROM and prints it in hex
@@ -245,7 +46,7 @@ static uint8_t device_found_sink(const uint8_t* rom) {
  * @note The output is enqueued into the UART ring buffer; call uart_tx_flush()
  *       afterwards so the full banner is transmitted before the main loop.
  */
-__STATIC_FORCEINLINE void search_devices_and_report(void) {
+static void search_devices_and_report(void) {
     uart_write_str("Searching 1-Wire bus...\r\n");
     uint8_t count = ds18b20_search_devices(device_found_sink, DS18B20_SEARCH_MAX_DEVICES);
     if (count == 0) {
@@ -268,7 +69,7 @@ __STATIC_FORCEINLINE void search_devices_and_report(void) {
  * @brief Print the ROM address of the currently selected device followed by ": "
  * @return Number of characters enqueued
  */
-__STATIC_FORCEINLINE int print_device_prefix(void) {
+static int print_device_prefix(void) {
     for (uint8_t i = 0; i < 8; i++) {
         uart_write_hex(found_roms[select_index][i]);
         if (i != 7) uart_tx_enqueue_byte(' ');
@@ -325,10 +126,9 @@ void ds18b20_complete(int16_t temp) {
  */
 int main(void) {
 
-    configure_system_clock(); // Configure system clock for MCU
+    app_init(); // System clock, UART and LED GPIO - single setup call
 
-    hardware_init(); // Initialize hardware peripherals (non-blocking)
-    uart_write_str("DS18B20 demo starting...\r\n"); // Enqueue startup message to UART buffer
+    uart_write_str("DS18B20 demo starting...\r\n"); // Enqueue startup message
     ds18b20_init(); // Initialize DS18B20 driver (non-blocking)
     search_devices_and_report(); // Blocking one-time bus scan (all sensors)
     uart_tx_flush(); // Block until the startup banner is fully transmitted

--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -70,6 +70,8 @@
 #define DS18B20_READ_SCRATCHPAD 0xBE
 /** @brief Total slots for Match ROM + 8-byte ROM + command */
 #define DS18B20_MATCH_SLOTS ((DS18B20_ROM_BYTES + 2) * DS18B20_BITS_PER_BYTE)
+/** @brief Slots for the invariant Match ROM + 8-byte ROM prefix (built on select) */
+#define DS18B20_PREFIX_SLOTS ((DS18B20_ROM_BYTES + 1) * DS18B20_BITS_PER_BYTE)
 /** @brief Threshold to distinguish short/long pulses (10µs) */
 #define SHORT_PULSE_MAX 0x0A
 /** @brief Number of DMA transfers for command transmission */
@@ -354,11 +356,12 @@ __STATIC_FORCEINLINE void encode_byte_pulses(uint8_t* out, uint8_t byte) {
 }
 
 /**
- * @brief Build the Match ROM command pulse sequence for the selected device
- * @param[in] cmd_byte Command byte to send after the ROM address
- * @note Fills ctx.addr_cmd with Match ROM (0x55) + selected ROM + command.
+ * @brief Build the invariant Match ROM prefix (0x55 + selected ROM)
+ * @note Fills the first DS18B20_PREFIX_SLOTS entries of ctx.addr_cmd.
+ *       The prefix depends only on the selected device, so it is built
+ *       once in ds18b20_select() and reused for every command.
  */
-__STATIC_FORCEINLINE void build_addr_cmd(uint8_t cmd_byte) {
+__STATIC_FORCEINLINE void build_addr_prefix(void) {
     uint8_t* p = ctx.addr_cmd;
     encode_byte_pulses(p, DS18B20_MATCH_ROM);
     p += DS18B20_BITS_PER_BYTE;
@@ -366,7 +369,16 @@ __STATIC_FORCEINLINE void build_addr_cmd(uint8_t cmd_byte) {
         encode_byte_pulses(p, ctx.selected_rom[i]);
         p += DS18B20_BITS_PER_BYTE;
     }
-    encode_byte_pulses(p, cmd_byte);
+}
+
+/**
+ * @brief Append one command byte to the pre-built Match ROM prefix
+ * @param[in] cmd_byte Command byte to send after the ROM address
+ * @note Requires build_addr_prefix() to have been called for the current
+ *       selected device. Only the last byte (8 slots) is re-encoded per call.
+ */
+__STATIC_FORCEINLINE void build_addr_cmd(uint8_t cmd_byte) {
+    encode_byte_pulses(&ctx.addr_cmd[DS18B20_PREFIX_SLOTS], cmd_byte);
 }
 
 /**
@@ -533,6 +545,7 @@ void ds18b20_select(const uint8_t* rom) {
     for (uint8_t i = 0; i < DS18B20_ROM_BYTES; i++) {
         ctx.selected_rom[i] = rom[i];
     }
+    build_addr_prefix(); // Build the invariant Match ROM prefix once per selection
     ctx.address_mode = 1;
 }
 


### PR DESCRIPTION
## Summary
Two commits on top of \eature/device-search\:

### 1. \cb45bd0\ refactor: extract shared app layer
- New \inc/app.h\ + \src/app.c\: lossless UART TX ring buffer, \pp_init()\ bundles clock+UART+LED setup, safe \uart_write_int()\ (full int32 range), strong \ds18b20_busy\ override
- \demo.c\ / \demo2.c\ reduced to demo logic only (callback + main), UART is now lossless in both, startup banners flushed
- \Makefile\: adds \src/app.c\, per-app \UART_TX_BUF_SIZE\ (demo 128, demo2 256)

### 2. \1ff42e7\ perf: cache invariant Match ROM prefix
- \ds18b20_select()\ builds the 0x55 + 8-byte ROM prefix once via \uild_addr_prefix()\
- \uild_addr_cmd()\ now only encodes the varying command byte (8 slots instead of 80)

## Testing
Both demos built clean (\-Wall -Werror -Wextra -Wpedantic\) and verified on real hardware (STM32F103C8T6):
- demo (single sensor, Skip ROM): stable readings
- demo2 (search + round-robin, Match ROM): bus scan + single-device measurements, CRC valid