### PR TITLE
Non-blocking device search + high-level API refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which left the driver idling in state 0 forever waiting for a UIF that never
   arrived. `ds18b20_search_devices()` now leaves a pending update flag so the
   first `ds18b20_poll()` call begins a measurement cycle immediately.
+- The device search reported every 1-Wire device on the bus, not just DS18B20
+  temperature sensors: other families (DS2401, DS1990, etc.) were stored and
+  polled as if they were DS18B20s. `ds18b20_search_devices()` now skips any
+  device whose ROM family code is not `DS18B20_FAMILY_CODE` (0x28), and the
+  `demo2` example double-checks the family code before storing an address.
 
 ## [1.0.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Blocking 1-Wire device search (`ds18b20_search_devices()`): enumerates all
   DS18B20 devices on the bus using the Search ROM command (0xF0) with the
   last-discrepancy algorithm and CRC-8 validation, and reports each device's
-  64-bit ROM address via a callback. The demo scans the bus once at startup
-  and prints every found device before starting normal measurements.
+  64-bit ROM address via a callback. The `demo2` example scans the bus once
+  at startup and prints every found device before starting normal measurements.
 - Per-device addressing (`ds18b20_select()`): the non-blocking measurement
   path can now target one specific DS18B20 by its 64-bit ROM address using
   the Match ROM command (0x55). Passing NULL keeps the legacy Skip ROM
   (single-sensor) behaviour. The demo measures a single device directly, or
   cycles through all found devices in turn when more than one is present.
+- Two example applications, selected with `make APP=demo|demo2`:
+  - `src/demo.c` — unconditional polling of a single sensor via Skip ROM
+    (the original, pre-search behaviour);
+  - `src/demo2.c` — startup device search plus sequential round-robin
+    polling of every sensor found (up to `DS18B20_SEARCH_MAX_DEVICES`).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Blocking 1-Wire device search (`ds18b20_search_devices()`): enumerates all
+  DS18B20 devices on the bus using the Search ROM command (0xF0) with the
+  last-discrepancy algorithm and CRC-8 validation, and reports each device's
+  64-bit ROM address via a callback. The demo scans the bus once at startup
+  and prints every found device before starting normal measurements.
+
 ## [1.0.0] - 2026-08-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   last-discrepancy algorithm and CRC-8 validation, and reports each device's
   64-bit ROM address via a callback. The demo scans the bus once at startup
   and prints every found device before starting normal measurements.
+- Per-device addressing (`ds18b20_select()`): the non-blocking measurement
+  path can now target one specific DS18B20 by its 64-bit ROM address using
+  the Match ROM command (0x55). Passing NULL keeps the legacy Skip ROM
+  (single-sensor) behaviour. The demo measures a single device directly, or
+  cycles through all found devices in turn when more than one is present.
+
+### Fixed
+
+- The non-blocking measurement state machine never started after the blocking
+  device search: the search clears the timer update flag on every operation,
+  which left the driver idling in state 0 forever waiting for a UIF that never
+  arrived. `ds18b20_search_devices()` now leaves a pending update flag so the
+  first `ds18b20_poll()` call begins a measurement cycle immediately.
 
 ## [1.0.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,38 +5,47 @@ are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
 ## [Unreleased]
 
 ### Added
-- Blocking 1-Wire device search (`ds18b20_search_devices()`): enumerates all
-  DS18B20 devices on the bus using the Search ROM command (0xF0) with the
-  last-discrepancy algorithm and CRC-8 validation, and reports each device's
-  64-bit ROM address via a callback. The `demo2` example scans the bus once
-  at startup and prints every found device before starting normal measurements.
-- Per-device addressing (`ds18b20_select()`): the non-blocking measurement
-  path can now target one specific DS18B20 by its 64-bit ROM address using
-  the Match ROM command (0x55). Passing NULL keeps the legacy Skip ROM
-  (single-sensor) behaviour. The demo measures a single device directly, or
-  cycles through all found devices in turn when more than one is present.
-- Two example applications, selected with `make APP=demo|demo2`:
-  - `src/demo.c` — unconditional polling of a single sensor via Skip ROM
-    (the original, pre-search behaviour);
-  - `src/demo2.c` — startup device search plus sequential round-robin
-    polling of every sensor found (up to `DS18B20_SEARCH_MAX_DEVICES`).
+
+- Low-level blocking 1-Wire primitives for custom protocols such as device
+  search: `ds18b20_reset()`, `ds18b20_write_bit()`, `ds18b20_read_bit()`,
+  `ds18b20_write_byte()`, `ds18b20_read_byte()`, `ds18b20_restore()`, and
+  `ds18b20_crc8()`. These busy-wait on hardware completion and are clearly
+  separated from the non-blocking measurement path. See `demo2.c` for a
+  complete Search ROM implementation built on these primitives.
+- Shared application layer (`inc/app.h`, `src/app.c`): lossless UART TX ring
+  buffer, `app_init()` for clock + UART + LED setup, and a default
+  `ds18b20_busy()` LED indicator. Both examples now `#include "app.h"` and
+  delegate hardware setup to the shared layer.
+- Match ROM prefix caching: `ds18b20_select()` builds the invariant 72-slot
+  Match ROM prefix once per selection, so each subsequent measurement patches
+  only the last byte (8 slots instead of 80).
+
+### Changed
+
+- **Breaking:** `ds18b20_search_devices()` removed from the library. The
+  blocking search algorithm now lives in `demo2.c` as `search_all_devices()`,
+  built on the public low-level primitives. Users who need device search can
+  copy and adapt the demo implementation.
+- Protocol constants (`DS18B20_SEARCH_ROM`, `DS18B20_MATCH_ROM`,
+  `DS18B20_CONVERT_T`, `DS18B20_READ_SCRATCHPAD`, `DS18B20_ROM_BYTES`,
+  `DS18B20_BITS_PER_BYTE`) moved from `src/ds18b20.c` to `inc/ds18b20.h`
+  so low-level API users can build custom protocols.
+- DMA transfer count sized to `slots-1` instead of using a sentinel value.
 
 ### Fixed
 
 - The non-blocking measurement state machine never started after the blocking
   device search: the search clears the timer update flag on every operation,
   which left the driver idling in state 0 forever waiting for a UIF that never
-  arrived. `ds18b20_search_devices()` now leaves a pending update flag so the
-  first `ds18b20_poll()` call begins a measurement cycle immediately.
+  arrived. The search now calls `ds18b20_restore()` so the first
+  `ds18b20_poll()` call begins a measurement cycle immediately.
 - The device search reported every 1-Wire device on the bus, not just DS18B20
   temperature sensors: other families (DS2401, DS1990, etc.) were stored and
-  polled as if they were DS18B20s. `ds18b20_search_devices()` now skips any
-  device whose ROM family code is not `DS18B20_FAMILY_CODE` (0x28), and the
-  `demo2` example double-checks the family code before storing an address.
+  polled as if they were DS18B20s. The search now skips any device whose ROM
+  family code is not `DS18B20_FAMILY_CODE` (0x28).
 
 ## [1.0.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Low-level blocking 1-Wire primitives for custom protocols such as device
-  search: `ds18b20_reset()`, `ds18b20_write_bit()`, `ds18b20_read_bit()`,
-  `ds18b20_write_byte()`, `ds18b20_read_byte()`, `ds18b20_restore()`, and
-  `ds18b20_crc8()`. These busy-wait on hardware completion and are clearly
-  separated from the non-blocking measurement path. See `demo2.c` for a
-  complete Search ROM implementation built on these primitives.
-- Shared application layer (`inc/app.h`, `src/app.c`): lossless UART TX ring
+- Non-blocking device search: `ds18b20_search_start()`, `ds18b20_search_poll()`,
+  `ds18b20_search_count()`. Implements the Maxim Search ROM (0xF0) algorithm as
+  a compact state machine that performs exactly one hardware operation per poll
+  call, then hands the timer back to the measurement path automatically. See
+  `demo2.c`.
+- Shared application layer (`inc/app.h`, `src/app.c`): non-blocking UART TX ring
   buffer, `app_init()` for clock + UART + LED setup, and a default
   `ds18b20_busy()` LED indicator. Both examples now `#include "app.h"` and
   delegate hardware setup to the shared layer.
@@ -25,19 +24,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Breaking:** `ds18b20_search_devices()` removed from the library. The
-  blocking search algorithm now lives in `demo2.c` as `search_all_devices()`,
-  built on the public low-level primitives. Users who need device search can
-  copy and adapt the demo implementation.
+- **Breaking:** the public API is now a small high-level interface only:
+  `ds18b20_init()`, `ds18b20_poll()`, `ds18b20_select()`, the weak callbacks
+  `ds18b20_busy()`/`ds18b20_complete()`, and the `ds18b20_search_*` family.
+  All low-level 1-Wire bus primitives (`ds18b20_bus_*`), `ds18b20_crc8()` and
+  the Search ROM state machine moved inside the library (`src/ds18b20.c`) and
+  became `static`; the separate `inc/ds18b20_search.h` /
+  `src/ds18b20_search.c` files were removed.
+- **Breaking:** the blocking low-level primitives (`ds18b20_reset()`,
+  `ds18b20_write_bit()`, `ds18b20_read_bit()`, `ds18b20_write_byte()`,
+  `ds18b20_read_byte()`) were removed.
+- UART TX is now fully non-blocking: `uart_tx_enqueue_byte()` drops a byte when
+  the ring buffer is full instead of busy-waiting, and the blocking
+  `uart_tx_flush()` was removed.
 - Protocol constants (`DS18B20_SEARCH_ROM`, `DS18B20_MATCH_ROM`,
-  `DS18B20_CONVERT_T`, `DS18B20_READ_SCRATCHPAD`, `DS18B20_ROM_BYTES`,
-  `DS18B20_BITS_PER_BYTE`) moved from `src/ds18b20.c` to `inc/ds18b20.h`
-  so low-level API users can build custom protocols.
+  `DS18B20_CONVERT_T`, `DS18B20_READ_SCRATCHPAD`, `DS18B20_BITS_PER_BYTE`)
+  are now private to `src/ds18b20.c`; the public header keeps only
+  `DS18B20_FAMILY_CODE`, `DS18B20_ROM_BYTES` and the error codes.
 - DMA transfer count sized to `slots-1` instead of using a sentinel value.
 
 ### Fixed
 
-- The non-blocking measurement state machine never started after the blocking
+- The non-blocking measurement state machine never started after a blocking
   device search: the search clears the timer update flag on every operation,
   which left the driver idling in state 0 forever waiting for a UIF that never
   arrived. The search now calls `ds18b20_restore()` so the first

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,14 @@
+# Select the example application: demo (single sensor, Skip ROM) or
+# demo2 (device search + sequential polling of every sensor on the bus)
+#   make            -> builds demo   (ds18b20_demo.elf)
+#   make APP=demo2  -> builds demo2  (ds18b20_demo2.elf)
+APP ?= demo
+ifeq ($(filter $(APP),demo demo2),)
+$(error APP must be 'demo' (single sensor) or 'demo2' (search + poll all))
+endif
+
 # Define the name of the project target and the build directory
-TARGET = ds18b20_demo
+TARGET = ds18b20_$(APP)
 BUILD_DIR = build
 
 # CMSIS directory structure for third-party build dependencies
@@ -7,7 +16,7 @@ CMSIS_CORE_DIR   = CMSIS/core
 CMSIS_DEVICE_DIR = CMSIS/device
 
 # Define the C source files, assembly source file, linker script, and preprocessor definitions
-SRC = $(CMSIS_DEVICE_DIR)/system_stm32f1xx.c src/demo.c src/ds18b20.c
+SRC = $(CMSIS_DEVICE_DIR)/system_stm32f1xx.c src/$(APP).c src/ds18b20.c
 ASM = $(CMSIS_DEVICE_DIR)/startup_stm32f103xb.s
 LDS = STM32F103XB_FLASH.ld
 MCU = -mcpu=cortex-m3 -mthumb

--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,17 @@ CMSIS_CORE_DIR   = CMSIS/core
 CMSIS_DEVICE_DIR = CMSIS/device
 
 # Define the C source files, assembly source file, linker script, and preprocessor definitions
-SRC = $(CMSIS_DEVICE_DIR)/system_stm32f1xx.c src/$(APP).c src/ds18b20.c
+SRC = $(CMSIS_DEVICE_DIR)/system_stm32f1xx.c src/$(APP).c src/ds18b20.c src/app.c
 ASM = $(CMSIS_DEVICE_DIR)/startup_stm32f103xb.s
 LDS = STM32F103XB_FLASH.ld
 MCU = -mcpu=cortex-m3 -mthumb
 DEF = -DSTM32F103xB
 INC = -I. -Iinc -I$(CMSIS_CORE_DIR) -I$(CMSIS_DEVICE_DIR)
+
+# Per-app USART1 TX ring buffer size (power of two), overrides the app.h default
+UART_TX_SIZE_demo  = 128
+UART_TX_SIZE_demo2 = 256
+DEF += -DUART_TX_BUF_SIZE=$(UART_TX_SIZE_$(APP))
 
 # Define additional preprocessor definitions based on conditional variables
 # make HSI_8MHZ=1  →  -DHSI_8MHZ=1  (run on HSI 8MHz instead of HSE+PLL 72MHz)

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ A bare-metal, register-level driver for the DS18B20 temperature sensor. This dri
 ```
 ├── inc/                    # Project header files
 │   ├── ds18b20.h           # Driver interface and constants
+│   ├── app.h               # Shared application layer (UART, clock, init)
 │   └── macro.h             # STM32 register access macros
 ├── src/                    # Project source files
+│   ├── app.c               # app_init(), UART TX ring buffer, busy LED
 │   ├── demo.c              # Example: single sensor, unconditional (Skip ROM)
 │   ├── demo2.c             # Example: device search + sequential poll of all
 │   └── ds18b20.c           # Main driver implementation
@@ -69,6 +71,8 @@ make debug APP=demo2  # debug build of demo2 (for J-Link/ST-Link)
 
 Notes:
 
+- Both examples use `app_init()` (from `inc/app.h`) to set up the system
+  clock, USART1 TX and the busy LED in a single call.
 - `demo` uses Skip ROM, so it is meant for a **single sensor** on the bus.
   With several sensors connected, all of them respond to the read command and
   the bus data collides (CRC failures are expected).
@@ -131,6 +135,11 @@ int main(void) {
 ```
 
 ### 3. Implement Callbacks (Optional)
+
+Both callbacks are optional. Default weak implementations are provided by the
+driver, and `src/app.c` additionally supplies a default `ds18b20_busy()` that
+drives the onboard LED (PC13). The examples override both: `ds18b20_busy()`
+switches the LED and `ds18b20_complete()` formats and prints the result.
 
 ```C
 // Busy indicator — e.g. LED toggling during measurement
@@ -387,7 +396,7 @@ Kickstart behavior
 ```C
 void ds18b20_init(void);
 ```
-Initialize the DS18B20 driver. Enables peripherals (GPIOA, TIM1, DMA1) and sets up the timer prescaler for 1µs resolution. System clock configuration is handled separately in the application (see `demo.c`). This function does NOT start the state machine.
+Initialize the DS18B20 driver. Enables peripherals (GPIOA, TIM1, DMA1) and sets up the timer prescaler for 1µs resolution. System clock configuration is handled separately in the application (see `app.c`). This function does NOT start the state machine.
 
 ```C
 void ds18b20_poll(void);

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ A bare-metal, register-level driver for the DS18B20 temperature sensor. This dri
 - Weak Function Callbacks: Hooks for driver busy state and measurement completion.
 - CRC Validation: CRC-8 ensures every sensor reading is checked for data integrity.
 - Device Search: Blocking Search ROM (0xF0) at startup to enumerate all
-  sensors on the bus and read their 64-bit ROM addresses.
+  DS18B20 sensors on the bus and read their 64-bit ROM addresses. Only devices
+  with the DS18B20 family code (0x28) are reported; other 1-Wire devices are
+  skipped.
 - Per-Device Addressing: Select one specific sensor by its ROM address
   (`ds18b20_select()`, Match ROM 0x55) for use with multiple devices on one bus.
 
@@ -399,9 +401,11 @@ uint8_t ds18b20_search_devices(uint8_t (*sink)(const uint8_t *rom), uint8_t max_
 ```
 Enumerates every DS18B20 device on the 1-Wire bus using the standard Maxim
 Search ROM (0xF0) algorithm with the last-discrepancy method and CRC-8
-validation. Invokes `sink` once per found device with its 64-bit ROM address
-(LSB first); the callback may return non-zero to stop early. Returns the
-number of devices found.
+validation. Only devices whose ROM family code is `DS18B20_FAMILY_CODE` (0x28)
+are reported; any other 1-Wire device on the bus is silently skipped. Invokes
+`sink` once per found device with its 64-bit ROM address (LSB first); the
+callback may return non-zero to stop early. Returns the number of devices
+found.
 
 **Note:** This is a **blocking** function (~15 ms per device) — it busy-waits
 on the timer update flag for the duration of the search. It is intended for

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ A bare-metal, register-level driver for the DS18B20 temperature sensor. This dri
 - State Machine Architecture: Event-driven operation controlled by hardware completion signals.
  - Weak Function Callbacks: Hooks for driver busy state and measurement completion.
  - CRC Validation: CRC-8 ensures every sensor reading is checked for data integrity.
- - Low-Level Blocking Primitives: Optional `ds18b20_reset()`, `ds18b20_write_bit()`,
-   `ds18b20_read_bit()`, `ds18b20_write_byte()`, `ds18b20_read_byte()`, and
-   `ds18b20_crc8()` for custom 1-Wire protocols (e.g., device search). These
-   busy-wait on hardware completion and are clearly separated from the
-   non-blocking measurement path.
+ - Non-Blocking Device Search: `ds18b20_search_start()`, `ds18b20_search_poll()`,
+   `ds18b20_search_count()` find every DS18B20 on the bus. The low-level
+   1-Wire bus primitives and the Search ROM state machine live inside the
+   driver, so the public API is a small high-level interface only — zero
+   busy-waits, consistent with the non-blocking measurement path.
  - Per-Device Addressing: Select one specific sensor by its ROM address
    (`ds18b20_select()`, Match ROM 0x55) for use with multiple devices on one bus.
 
@@ -32,14 +32,15 @@ A bare-metal, register-level driver for the DS18B20 temperature sensor. This dri
 
 ```
 ├── inc/                    # Project header files
-│   ├── ds18b20.h           # Driver interface and constants
+│   ├── ds18b20.h           # Driver interface (high-level API) and constants
 │   ├── app.h               # Shared application layer (UART, clock, init)
 │   └── macro.h             # STM32 register access macros
 ├── src/                    # Project source files
 │   ├── app.c               # app_init(), UART TX ring buffer, busy LED
 │   ├── demo.c              # Example: single sensor, unconditional (Skip ROM)
 │   ├── demo2.c             # Example: device search + sequential poll of all
-│   └── ds18b20.c           # Main driver implementation
+│   └── ds18b20.c           # Driver: state machine + internal bus primitives
+│                           #          + non-blocking Search ROM
 ├── CMSIS/                  # Build-time dependencies (gitignored)
 │   ├── core/               # ARM CMSIS 5 core headers
 │   └── device/             # STM32F1 device headers and startup
@@ -122,9 +123,9 @@ in main loop) — fully non-blocking, no interrupts.
 int main(void) {
     ds18b20_init();  // One-time initialization
 
-    // Optional: use low-level blocking primitives for custom protocols
-    // (e.g., device search). See demo2.c for a complete Search ROM example.
-    // After using primitives, call ds18b20_restore() before polling.
+    // Optional: run the non-blocking device search to find every sensor on
+    // the bus. See demo2.c for a complete example. The search hands the
+    // driver back to poll() automatically when finished.
 
     // Optional: measure one specific device by its ROM address
     ds18b20_select(my_rom);  // my_rom from a bus search
@@ -339,11 +340,13 @@ This driver uses an advanced technique that combines multiple hardware features:
 3. Hardware Completion Events: The state machine advances only when the hardware timer signals that its current automated task is complete.
  4. Minimal CPU During Operations: The CPU is only actively involved to set up a hardware operation and to process the result once it completes.
 
-> The driver also exposes low-level blocking primitives (`ds18b20_reset()`, `ds18b20_write_bit()`,
-> `ds18b20_read_bit()`, `ds18b20_write_byte()`, `ds18b20_read_byte()`, `ds18b20_crc8()`)
-> for custom 1-Wire protocols such as device search. These busy-wait on hardware
-> completion and are clearly separated from the non-blocking measurement path.
-> See `demo2.c` for a complete Search ROM implementation built on these primitives.
+> The driver ships with a built-in non-blocking device search
+> (`ds18b20_search_*`) for multi-sensor buses. The Maxim Search ROM (0xF0)
+> algorithm is implemented as a compact state machine inside the driver; it
+> performs exactly one hardware-timed operation per poll call — consistent with
+> the non-blocking measurement path, there are no busy-waits anywhere. All
+> low-level bus operations stay internal to the driver. See `demo2.c` for a
+> complete Search ROM example.
 
 ### Hardware Resources Used
 
@@ -436,48 +439,31 @@ void ds18b20_poll(void);
 ```
 The Core Driver Function: Must be called from the main loop. It checks the Timer Update Flag (UIF). If the flag is set, it means the hardware has finished the previous operation (e.g., sending a command, waiting for conversion). The function then clears the flag and advances the internal state machine to the next step. The driver's state is persistent, so this function can be called at any rate without risk of getting stuck.
 
-### Low-Level Blocking Primitives
+### Internal 1-Wire Bus Primitives
 
-These functions provide direct, bit-level access to the 1-Wire bus for custom
-protocols (e.g., device search). They busy-wait on hardware completion and use
-the same TIM1/DMA resources as the non-blocking state machine, so they **must
-not be called while polling is active**. After using these primitives, call
-`ds18b20_restore()` before starting `ds18b20_poll()`. See `demo2.c` for a
-complete Search ROM implementation built on these primitives.
+The non-blocking 1-Wire bus primitives (`ds18b20_bus_reset()`,
+`ds18b20_bus_done()`, `ds18b20_bus_present()`, `ds18b20_bus_encode_byte()`,
+`ds18b20_bus_write_slots()`, `ds18b20_bus_write_bit()`,
+`ds18b20_bus_read_pair()`, `ds18b20_bus_pair_id()`, `ds18b20_bus_pair_cmp()`),
+`ds18b20_crc8()` and the Search ROM state machine are **private to the driver**
+(`static` in `src/ds18b20.c`). They are not part of the public API; the
+built-in device search is the supported way to enumerate the bus.
 
-```C
-uint8_t ds18b20_reset(void);
-```
-Performs a 1-Wire bus reset and checks for a presence pulse. Returns 1 if at
-least one device answered, 0 otherwise.
+### Device Search
 
 ```C
-void ds18b20_write_bit(uint8_t bit);
+void ds18b20_search_start(ds18b20_search_sink_t sink, uint8_t max_devices);
+uint8_t ds18b20_search_poll(void);
+uint8_t ds18b20_search_count(void);
 ```
-Writes one bit to the bus as a single hardware-timed slot. `bit = 1` produces a
-short low pulse (~5µs); `bit = 0` produces a long low pulse (~60µs).
-
-```C
-uint8_t ds18b20_read_bit(void);
-```
-Reads one bit from the bus as a single hardware-timed slot and returns its value.
-
-```C
-void ds18b20_write_byte(uint8_t byte);
-uint8_t ds18b20_read_byte(void);
-```
-Write/read one byte, LSB first, as 8 consecutive bit slots.
-
-```C
-void ds18b20_restore(void);
-```
-Restores the non-blocking state machine after using low-level primitives. Call
-this before the first `ds18b20_poll()` to re-prime the measurement cycle.
-
-```C
-uint8_t ds18b20_crc8(const uint8_t* data, uint8_t len);
-```
-Calculates the Dallas/Maxim CRC-8 checksum over a byte buffer.
+Non-blocking Maxim Search ROM (0xF0) over the whole bus, implemented as a
+compact state machine that performs exactly one hardware operation per
+`ds18b20_search_poll()` call. `sink` is invoked once per found DS18B20 device
+with its 8-byte ROM address; `max_devices` caps the reported count. Poll
+`ds18b20_search_poll()` from the main loop until it returns 1 — it restores
+`ds18b20_poll()` state automatically. `ds18b20_search_count()` returns how many
+devices were found. Only devices with family code `DS18B20_FAMILY_CODE` (0x28)
+are reported. See `demo2.c`.
 
 ### Per-Device Addressing
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,40 @@ the debug sidebar.
 **ST-Link:** Connect an ST-Link programmer (built into most Blue Pill
 boards) via SWD.
 
+## Comparison with Common 1-Wire Techniques
+
+The DS18B20 uses the 1-Wire bus protocol, which communicates over a single data
+line with strict timing requirements. Several approaches exist to handle this
+protocol on embedded systems:
+
+| Technique | How it works | Blocking? | Timing precision | Typical use |
+|---|---|---|---|---|
+| **Bit-banging + delay** (e.g. OneWire Arduino) | GPIO toggling with `delayMicroseconds()`, interrupts disabled | Yes | Low (compiler/optimization dependent) | Hobbyist Arduino projects |
+| **Bit-banging + timer ISR** | Timer interrupt drives GPIO transitions | Semi- | Medium | RTOS-based firmware |
+| **UART bit-banging** | UART at 9600/115200 baud emulates 1-Wire timings | Depends | Medium | Systems with spare UARTs |
+| **Hardware 1-Wire master** | Dedicated IC (DS2482) or kernel subsystem (Linux w1-gpio) | No | High | Linux SBCs, complex systems |
+| **Timer + DMA + One-Pulse Mode** (this driver) | DMA feeds CCR values autonomously; timer self-disables after each transaction | No | High (1µs resolution, zero jitter) | STM32 resource-constrained firmware |
+
+### Trade-offs
+
+**Cost.** This driver consumes dedicated hardware resources — TIM1, DMA1
+channels 3/4, and PA8 — that cannot be used for other purposes. Bit-banging
+approaches need only a single GPIO pin and no DMA, making them more portable
+across MCUs with limited peripherals.
+
+**Precision vs. portability.** Timer+DMA provides deterministic 1µs resolution
+with zero jitter, because the CPU is never in the timing-critical path. Software
+delays degrade under interrupt load, and even timer-ISR approaches incur jitter
+from preemption. The trade-off is complexity: this driver's hardware configuration
+is ~150 lines of register-level code versus ~20 lines for a typical bit-bang
+implementation.
+
+**CPU availability.** Both bit-banging and this driver run without interrupts, but
+bit-banging blocks the CPU for the entire transaction (~15ms per measurement
+cycle). This driver frees the CPU during the entire measurement — the state
+machine advances only when hardware signals completion via the timer update flag,
+so the main loop remains free for other tasks between polls.
+
 ## Architecture
 
 ### Hybrid Hardware Automation

--- a/README.md
+++ b/README.md
@@ -303,10 +303,12 @@ protocol on embedded systems:
 
 ### Trade-offs
 
-**Cost.** This driver consumes dedicated hardware resources — TIM1, DMA1
-channels 3/4, and PA8 — that cannot be used for other purposes. Bit-banging
-approaches need only a single GPIO pin and no DMA, making them more portable
-across MCUs with limited peripherals.
+**Cost.** This driver consumes dedicated hardware resources — TIM1 and two DMA1
+channels (CH3 for input capture, CH4 for the CCR1 feed) — that cannot be used
+for other purposes. The 1-Wire data line itself occupies PA8, but any approach
+needs a GPIO pin for the bus, so that is not an extra cost. Bit-banging
+approaches, by contrast, need only that one pin and no DMA, making them more
+portable across MCUs with limited peripherals.
 
 **Precision vs. portability.** Timer+DMA provides deterministic 1µs resolution
 with zero jitter, because the CPU is never in the timing-critical path. Software
@@ -314,12 +316,6 @@ delays degrade under interrupt load, and even timer-ISR approaches incur jitter
 from preemption. The trade-off is complexity: this driver's hardware configuration
 is ~150 lines of register-level code versus ~20 lines for a typical bit-bang
 implementation.
-
-**CPU availability.** Both bit-banging and this driver run without interrupts, but
-bit-banging blocks the CPU for the entire transaction (~15ms per measurement
-cycle). This driver frees the CPU during the entire measurement — the state
-machine advances only when hardware signals completion via the timer update flag,
-so the main loop remains free for other tasks between polls.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ A bare-metal, register-level driver for the DS18B20 temperature sensor. This dri
 - CRC Validation: CRC-8 ensures every sensor reading is checked for data integrity.
 - Device Search: Blocking Search ROM (0xF0) at startup to enumerate all
   sensors on the bus and read their 64-bit ROM addresses.
+- Per-Device Addressing: Select one specific sensor by its ROM address
+  (`ds18b20_select()`, Match ROM 0x55) for use with multiple devices on one bus.
 
 ## Requirements
 
@@ -89,6 +91,9 @@ int main(void) {
 
     // Optional: enumerate all devices on the bus (blocking, startup only)
     uint8_t n = ds18b20_search_devices(my_sink, 16);
+
+    // Optional: measure one specific device by its ROM address
+    if (n > 0) ds18b20_select(my_rom);  // my_rom captured in my_sink
 
     while (1) {
         ds18b20_poll();  // Call repeatedly from main loop
@@ -308,7 +313,10 @@ Kickstart behavior
 
 - CONVERT (state 2)
   - On UIF, check_presence() with ctx.edge[].
-    - If present: send_command(conv_cmd) “Skip ROM 0xCC + Convert T 0x44” via CH1+DMA (16 slots, RCR=15); set state=3.
+    - If present: send convert command via CH1+DMA. With no selected device,
+      this is "Skip ROM 0xCC + Convert T 0x44" (16 slots, RCR=15). With a
+      device selected via ds18b20_select(), it is "Match ROM 0x55 + 8-byte ROM
+      + Convert T 0x44" (80 slots, RCR=79). Set state=3.
     - Else: report NO_SENSOR; start 5s pause; set state=0.
 
 - WAIT (state 3)
@@ -319,7 +327,10 @@ Kickstart behavior
 
 - REQUEST (state 5)
   - On UIF, check_presence().
-    - If present: send_command(read_cmd) “Skip ROM 0xCC + Read 0xBE” via CH1+DMA (16 slots); set state=6.
+    - If present: send read command via CH1+DMA. With no selected device,
+      this is "Skip ROM 0xCC + Read Scratchpad 0xBE" (16 slots). With a device
+      selected, it is "Match ROM 0x55 + 8-byte ROM + Read Scratchpad 0xBE"
+      (80 slots). Set state=6.
     - Else: report NO_SENSOR; start 5s pause; set state=0.
 
 - READ (state 6)
@@ -334,10 +345,10 @@ Kickstart behavior
 | :----------- | :------------- | :--------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------- |
 | **0**        | **IDLE**       | Initial state. Immediately falls through into START with no events required; prepares the context for a new measurement cycle by initializing the data union. | State 1 (START)                                                                                             |
 | **1**        | **START**      | Begins the measurement cycle. Turns on the user LED (if implemented) and initiates a **1-Wire bus reset** sequence to detect devices.     | State 2 (CONVERT)                                                                                           |
-| **2**        | **CONVERT**    | Checks if a DS18B20 responded correctly to the reset. If present, sends the **Convert T (`0x44`)** command. If not, reports an error.     | State 3 (WAIT) on success.<br/>State 0 (IDLE) after pause on error.                                         |
+| **2**        | **CONVERT**    | Checks if a DS18B20 responded correctly to the reset. If present, sends the **Convert T (`0x44`)** command — either via **Skip ROM (0xCC)** to all devices, or via **Match ROM (0x55) + device ROM** to the device selected with `ds18b20_select()`. If not, reports an error.     | State 3 (WAIT) on success.<br/>State 0 (IDLE) after pause on error. |
 | **3**        | **WAIT**       | Starts a non-blocking timer delay (~750 ms) to wait for the temperature conversion inside the DS18B20 to complete.                       | State 4 (CONTINUE)                                                                                          |
 | **4**        | **CONTINUE**   | Initiates a second **1-Wire bus reset** sequence to prepare for reading the converted data.                                              | State 5 (REQUEST)                                                                                           |
-| **5**        | **REQUEST**    | Checks for the DS18B20's presence again. If present, sends the **Read Scratchpad (`0xBE`)** command. If not, reports an error.            | State 6 (READ) on success.<br/>State 0 (IDLE) after pause on error.                                         |
+| **5**        | **REQUEST**    | Checks for the DS18B20's presence again. If present, sends the **Read Scratchpad (`0xBE`)** command — via **Skip ROM (0xCC)** or **Match ROM (0x55) + device ROM** depending on the selected device. If not, reports an error.            | State 6 (READ) on success.<br/>State 0 (IDLE) after pause on error.                                         |
 | **6**        | **READ**       | Reads the **9 bytes of scratchpad data** (including CRC) from the sensor using precise pulse-width measurement via timer input capture. | State 7 (DECODE)                                                                                            |
 | **7**        | **DECODE**     | **Decodes** the captured pulse widths into data bytes, validates the **CRC**, converts the raw temperature, and reports the result. Turns off the user LED. Starts a pause before the next cycle. | State 0 (IDLE) after pause.                                                                                 |
 
@@ -370,8 +381,22 @@ number of devices found.
 on the timer update flag for the duration of the search. It is intended for
 **one-time use at startup**, before the main loop starts calling
 `ds18b20_poll()`. It reuses the same hardware-timed 1-Wire primitives but does
-not affect the non-blocking measurement path, which continues to use Skip-ROM
-(single-sensor) addressing.
+not affect the non-blocking measurement path.
+
+### Per-Device Addressing
+
+```C
+void ds18b20_select(const uint8_t *rom);
+```
+Selects which DS18B20 device the non-blocking measurement path targets, using
+its 64-bit ROM address (LSB first, as reported by `ds18b20_search_devices()`).
+With a device selected, the driver sends the **Match ROM (0x55)** command plus
+the device ROM before every Convert T / Read Scratchpad operation, so only that
+device responds. Pass `NULL` to clear the selection and return to the legacy
+**Skip ROM (0xCC)** single-sensor behaviour.
+
+The demo measures the single device directly when exactly one is found, and
+cycles through all found devices in turn when several are present.
 
 ### Weak Callbacks
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A bare-metal, register-level driver for the DS18B20 temperature sensor. This dri
 - State Machine Architecture: Event-driven operation controlled by hardware completion signals.
 - Weak Function Callbacks: Hooks for driver busy state and measurement completion.
 - CRC Validation: CRC-8 ensures every sensor reading is checked for data integrity.
+- Device Search: Blocking Search ROM (0xF0) at startup to enumerate all
+  sensors on the bus and read their 64-bit ROM addresses.
 
 ## Requirements
 
@@ -84,6 +86,9 @@ in main loop) — fully non-blocking, no interrupts.
 ```C
 int main(void) {
     ds18b20_init();  // One-time initialization
+
+    // Optional: enumerate all devices on the bus (blocking, startup only)
+    uint8_t n = ds18b20_search_devices(my_sink, 16);
 
     while (1) {
         ds18b20_poll();  // Call repeatedly from main loop
@@ -260,6 +265,11 @@ This driver uses an advanced technique that combines multiple hardware features:
 3. Hardware Completion Events: The state machine advances only when the hardware timer signals that its current automated task is complete.
 4. Minimal CPU During Operations: The CPU is only actively involved to set up a hardware operation and to process the result once it completes.
 
+> The one deliberate exception is `ds18b20_search_devices()`: it is a blocking
+> startup-only helper that reuses the same hardware-timed 1-Wire primitives
+> (timer + DMA) but waits for each slot synchronously, because the bus scan
+> runs once at boot when the CPU is otherwise idle.
+
 ### Hardware Resources Used
 
 - TIM1 & Channels 1, 2, 4: The core timer resources.
@@ -344,6 +354,24 @@ Initialize the DS18B20 driver. Enables peripherals (GPIOA, TIM1, DMA1) and sets 
 void ds18b20_poll(void);
 ```
 The Core Driver Function: Must be called from the main loop. It checks the Timer Update Flag (UIF). If the flag is set, it means the hardware has finished the previous operation (e.g., sending a command, waiting for conversion). The function then clears the flag and advances the internal state machine to the next step. The driver's state is persistent, so this function can be called at any rate without risk of getting stuck.
+
+### Device Search (blocking)
+
+```C
+uint8_t ds18b20_search_devices(uint8_t (*sink)(const uint8_t *rom), uint8_t max_devices);
+```
+Enumerates every DS18B20 device on the 1-Wire bus using the standard Maxim
+Search ROM (0xF0) algorithm with the last-discrepancy method and CRC-8
+validation. Invokes `sink` once per found device with its 64-bit ROM address
+(LSB first); the callback may return non-zero to stop early. Returns the
+number of devices found.
+
+**Note:** This is a **blocking** function (~15 ms per device) — it busy-waits
+on the timer update flag for the duration of the search. It is intended for
+**one-time use at startup**, before the main loop starts calling
+`ds18b20_poll()`. It reuses the same hardware-timed 1-Wire primitives but does
+not affect the non-blocking measurement path, which continues to use Skip-ROM
+(single-sensor) addressing.
 
 ### Weak Callbacks
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ A bare-metal, register-level driver for the DS18B20 temperature sensor. This dri
 │   ├── ds18b20.h           # Driver interface and constants
 │   └── macro.h             # STM32 register access macros
 ├── src/                    # Project source files
-│   ├── demo.c              # Example application with UART output
+│   ├── demo.c              # Example: single sensor, unconditional (Skip ROM)
+│   ├── demo2.c             # Example: device search + sequential poll of all
 │   └── ds18b20.c           # Main driver implementation
 ├── CMSIS/                  # Build-time dependencies (gitignored)
 │   ├── core/               # ARM CMSIS 5 core headers
@@ -48,6 +49,31 @@ A bare-metal, register-level driver for the DS18B20 temperature sensor. This dri
 ├── Makefile
 └── stm32f103cb.jflash      # J-Flash project file
 ```
+
+## Examples
+
+Two ready-to-run example applications are provided; select one with `APP`:
+
+| APP     | File             | Behaviour                                                        |
+|---------|------------------|------------------------------------------------------------------|
+| `demo`  | `src/demo.c`     | Unconditional polling of a single DS18B20 via Skip ROM (0xCC).   |
+| `demo2` | `src/demo2.c`    | Startup device search + sequential polling of every sensor found (up to `DS18B20_SEARCH_MAX_DEVICES`). |
+
+```bash
+make                # build demo  -> build/ds18b20_demo.elf
+make APP=demo2      # build demo2 -> build/ds18b20_demo2.elf
+make debug APP=demo2  # debug build of demo2 (for J-Link/ST-Link)
+```
+
+Notes:
+
+- `demo` uses Skip ROM, so it is meant for a **single sensor** on the bus.
+  With several sensors connected, all of them respond to the read command and
+  the bus data collides (CRC failures are expected).
+- `demo2` measures the devices found at startup one at a time, in round-robin
+  order. With exactly one sensor it behaves like `demo`.
+- Programming targets (`make jprogram` / `make program`) flash whichever
+  example is currently selected by `APP`.
 
 ## Hardware Connections
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,15 @@ A bare-metal, register-level driver for the DS18B20 temperature sensor. This dri
 - Zero Interrupts: Does not use any NVIC interrupts. Fully polled operation.
 - Hardware Automation: Uses TIM1 Output Compare and Input Capture with DMA to automate waveform generation and data capture.
 - State Machine Architecture: Event-driven operation controlled by hardware completion signals.
-- Weak Function Callbacks: Hooks for driver busy state and measurement completion.
-- CRC Validation: CRC-8 ensures every sensor reading is checked for data integrity.
-- Device Search: Blocking Search ROM (0xF0) at startup to enumerate all
-  DS18B20 sensors on the bus and read their 64-bit ROM addresses. Only devices
-  with the DS18B20 family code (0x28) are reported; other 1-Wire devices are
-  skipped.
-- Per-Device Addressing: Select one specific sensor by its ROM address
-  (`ds18b20_select()`, Match ROM 0x55) for use with multiple devices on one bus.
+ - Weak Function Callbacks: Hooks for driver busy state and measurement completion.
+ - CRC Validation: CRC-8 ensures every sensor reading is checked for data integrity.
+ - Low-Level Blocking Primitives: Optional `ds18b20_reset()`, `ds18b20_write_bit()`,
+   `ds18b20_read_bit()`, `ds18b20_write_byte()`, `ds18b20_read_byte()`, and
+   `ds18b20_crc8()` for custom 1-Wire protocols (e.g., device search). These
+   busy-wait on hardware completion and are clearly separated from the
+   non-blocking measurement path.
+ - Per-Device Addressing: Select one specific sensor by its ROM address
+   (`ds18b20_select()`, Match ROM 0x55) for use with multiple devices on one bus.
 
 ## Requirements
 
@@ -121,11 +122,12 @@ in main loop) — fully non-blocking, no interrupts.
 int main(void) {
     ds18b20_init();  // One-time initialization
 
-    // Optional: enumerate all devices on the bus (blocking, startup only)
-    uint8_t n = ds18b20_search_devices(my_sink, 16);
+    // Optional: use low-level blocking primitives for custom protocols
+    // (e.g., device search). See demo2.c for a complete Search ROM example.
+    // After using primitives, call ds18b20_restore() before polling.
 
     // Optional: measure one specific device by its ROM address
-    if (n > 0) ds18b20_select(my_rom);  // my_rom captured in my_sink
+    ds18b20_select(my_rom);  // my_rom from a bus search
 
     while (1) {
         ds18b20_poll();  // Call repeatedly from main loop
@@ -335,12 +337,13 @@ This driver uses an advanced technique that combines multiple hardware features:
 1. No Software Delays: No `delay_us()` or similar functions.
 2. No Interrupts: Does not configure or use the NVIC. Fully deterministic.
 3. Hardware Completion Events: The state machine advances only when the hardware timer signals that its current automated task is complete.
-4. Minimal CPU During Operations: The CPU is only actively involved to set up a hardware operation and to process the result once it completes.
+ 4. Minimal CPU During Operations: The CPU is only actively involved to set up a hardware operation and to process the result once it completes.
 
-> The one deliberate exception is `ds18b20_search_devices()`: it is a blocking
-> startup-only helper that reuses the same hardware-timed 1-Wire primitives
-> (timer + DMA) but waits for each slot synchronously, because the bus scan
-> runs once at boot when the CPU is otherwise idle.
+> The driver also exposes low-level blocking primitives (`ds18b20_reset()`, `ds18b20_write_bit()`,
+> `ds18b20_read_bit()`, `ds18b20_write_byte()`, `ds18b20_read_byte()`, `ds18b20_crc8()`)
+> for custom 1-Wire protocols such as device search. These busy-wait on hardware
+> completion and are clearly separated from the non-blocking measurement path.
+> See `demo2.c` for a complete Search ROM implementation built on these primitives.
 
 ### Hardware Resources Used
 
@@ -433,24 +436,48 @@ void ds18b20_poll(void);
 ```
 The Core Driver Function: Must be called from the main loop. It checks the Timer Update Flag (UIF). If the flag is set, it means the hardware has finished the previous operation (e.g., sending a command, waiting for conversion). The function then clears the flag and advances the internal state machine to the next step. The driver's state is persistent, so this function can be called at any rate without risk of getting stuck.
 
-### Device Search (blocking)
+### Low-Level Blocking Primitives
+
+These functions provide direct, bit-level access to the 1-Wire bus for custom
+protocols (e.g., device search). They busy-wait on hardware completion and use
+the same TIM1/DMA resources as the non-blocking state machine, so they **must
+not be called while polling is active**. After using these primitives, call
+`ds18b20_restore()` before starting `ds18b20_poll()`. See `demo2.c` for a
+complete Search ROM implementation built on these primitives.
 
 ```C
-uint8_t ds18b20_search_devices(uint8_t (*sink)(const uint8_t *rom), uint8_t max_devices);
+uint8_t ds18b20_reset(void);
 ```
-Enumerates every DS18B20 device on the 1-Wire bus using the standard Maxim
-Search ROM (0xF0) algorithm with the last-discrepancy method and CRC-8
-validation. Only devices whose ROM family code is `DS18B20_FAMILY_CODE` (0x28)
-are reported; any other 1-Wire device on the bus is silently skipped. Invokes
-`sink` once per found device with its 64-bit ROM address (LSB first); the
-callback may return non-zero to stop early. Returns the number of devices
-found.
+Performs a 1-Wire bus reset and checks for a presence pulse. Returns 1 if at
+least one device answered, 0 otherwise.
 
-**Note:** This is a **blocking** function (~15 ms per device) — it busy-waits
-on the timer update flag for the duration of the search. It is intended for
-**one-time use at startup**, before the main loop starts calling
-`ds18b20_poll()`. It reuses the same hardware-timed 1-Wire primitives but does
-not affect the non-blocking measurement path.
+```C
+void ds18b20_write_bit(uint8_t bit);
+```
+Writes one bit to the bus as a single hardware-timed slot. `bit = 1` produces a
+short low pulse (~5µs); `bit = 0` produces a long low pulse (~60µs).
+
+```C
+uint8_t ds18b20_read_bit(void);
+```
+Reads one bit from the bus as a single hardware-timed slot and returns its value.
+
+```C
+void ds18b20_write_byte(uint8_t byte);
+uint8_t ds18b20_read_byte(void);
+```
+Write/read one byte, LSB first, as 8 consecutive bit slots.
+
+```C
+void ds18b20_restore(void);
+```
+Restores the non-blocking state machine after using low-level primitives. Call
+this before the first `ds18b20_poll()` to re-prime the measurement cycle.
+
+```C
+uint8_t ds18b20_crc8(const uint8_t* data, uint8_t len);
+```
+Calculates the Dallas/Maxim CRC-8 checksum over a byte buffer.
 
 ### Per-Device Addressing
 
@@ -458,11 +485,11 @@ not affect the non-blocking measurement path.
 void ds18b20_select(const uint8_t *rom);
 ```
 Selects which DS18B20 device the non-blocking measurement path targets, using
-its 64-bit ROM address (LSB first, as reported by `ds18b20_search_devices()`).
-With a device selected, the driver sends the **Match ROM (0x55)** command plus
-the device ROM before every Convert T / Read Scratchpad operation, so only that
-device responds. Pass `NULL` to clear the selection and return to the legacy
-**Skip ROM (0xCC)** single-sensor behaviour.
+its 64-bit ROM address (LSB first, e.g. from a bus search). With a device
+selected, the driver sends the **Match ROM (0x55)** command plus the device ROM
+before every Convert T / Read Scratchpad operation, so only that device
+responds. Pass `NULL` to clear the selection and return to the legacy **Skip
+ROM (0xCC)** single-sensor behaviour.
 
 The demo measures the single device directly when exactly one is found, and
 cycles through all found devices in turn when several are present.

--- a/inc/app.h
+++ b/inc/app.h
@@ -9,7 +9,7 @@
  * Usage:
  * 1. #include "app.h" (defines UART_TX_BUF_SIZE, or -D on the command line)
  * 2. Call app_init() once at startup
- * 3. Use uart_write_*() to enqueue strings to the lossless TX ring buffer
+ * 3. Use uart_write_*() to enqueue strings to the non-blocking TX ring buffer
  * 4. Call uart_poll_tx() periodically to feed the UART from the buffer
  */
 
@@ -45,39 +45,33 @@ void app_init(void);
 void uart_poll_tx(void);
 
 /**
- * @brief Enqueue a single byte into the USART1 TX ring buffer (lossless)
+ * @brief Enqueue a single byte into the USART1 TX ring buffer (non-blocking)
  * @param[in] b Byte to enqueue
- * @note Blocks only while the buffer is full, polling uart_poll_tx() to make
- *       room - a byte is never dropped
+ * @return 1 if enqueued, 0 if the buffer is full (byte dropped)
+ * @note Never blocks: when the buffer is full the byte is dropped so the
+ *       caller's code path stays non-blocking.
  */
-void uart_tx_enqueue_byte(uint8_t b);
+uint8_t uart_tx_enqueue_byte(uint8_t b);
 
 /**
- * @brief Enqueue a null-terminated string (lossless)
+ * @brief Enqueue a null-terminated string (non-blocking)
  * @param[in] s Null-terminated string to enqueue
- * @return Number of characters enqueued
+ * @return Number of characters actually enqueued (may be less than strlen)
  */
 int uart_write_str(const char* s);
 
 /**
- * @brief Enqueue an integer as a decimal string (lossless)
+ * @brief Enqueue an integer as a decimal string (non-blocking)
  * @param[in] value Integer value to enqueue (full 32-bit range supported)
- * @return Number of characters enqueued
+ * @return Number of characters actually enqueued
  */
 int uart_write_int(int value);
 
 /**
- * @brief Enqueue a byte as two uppercase hexadecimal digits
+ * @brief Enqueue a byte as two uppercase hexadecimal digits (non-blocking)
  * @param[in] b Byte to enqueue
- * @return Number of characters enqueued (always 2)
+ * @return Number of characters actually enqueued (0, 1 or 2)
  */
 int uart_write_hex(uint8_t b);
-
-/**
- * @brief Blocking drain of the USART1 TX ring buffer
- * @note Waits until every enqueued byte has been shifted out (TC set).
- *       Use once at startup so banners are never truncated.
- */
-void uart_tx_flush(void);
 
 #endif // APP_H

--- a/inc/app.h
+++ b/inc/app.h
@@ -1,0 +1,83 @@
+/**
+ * @file app.h
+ * @brief Shared application layer for the DS18B20 example projects
+ * 
+ * Bundles everything an example application needs: the DS18B20 driver API
+ * plus a small platform layer (system clock, USART1 TX ring buffer, busy
+ * LED) behind a single header, so the demos stay short and readable.
+ * 
+ * Usage:
+ * 1. #include "app.h" (defines UART_TX_BUF_SIZE, or -D on the command line)
+ * 2. Call app_init() once at startup
+ * 3. Use uart_write_*() to enqueue strings to the lossless TX ring buffer
+ * 4. Call uart_poll_tx() periodically to feed the UART from the buffer
+ */
+
+#ifndef APP_H
+#define APP_H
+
+#include "ds18b20.h"
+#include <stdint.h>
+
+#ifndef UART_TX_BUF_SIZE
+#define UART_TX_BUF_SIZE 128u /**< Default TX ring buffer size (power of two) */
+#endif
+
+#if (UART_TX_BUF_SIZE & (UART_TX_BUF_SIZE - 1u)) != 0
+#error "UART_TX_BUF_SIZE must be a power of two (e.g., 32, 64, 128, 256)."
+#endif
+
+/** Mask for ring buffer index wrapping (power of two optimization) */
+#define UART_TX_IDX_MASK (UART_TX_BUF_SIZE - 1u)
+/** UART baud rate register value with rounding for accuracy */
+#define USART_BRR_CALC(PCLK, BAUD) (((PCLK) + ((BAUD) / 2)) / (BAUD))
+
+/**
+ * @brief Initialize system clock, USART1 TX and the busy LED GPIO
+ * @note One call instead of configure_system_clock() + hardware_init()
+ */
+void app_init(void);
+
+/**
+ * @brief Advance USART1 transmission by at most one byte (non-blocking)
+ * @note Must be called periodically to feed the UART from the ring buffer
+ */
+void uart_poll_tx(void);
+
+/**
+ * @brief Enqueue a single byte into the USART1 TX ring buffer (lossless)
+ * @param[in] b Byte to enqueue
+ * @note Blocks only while the buffer is full, polling uart_poll_tx() to make
+ *       room - a byte is never dropped
+ */
+void uart_tx_enqueue_byte(uint8_t b);
+
+/**
+ * @brief Enqueue a null-terminated string (lossless)
+ * @param[in] s Null-terminated string to enqueue
+ * @return Number of characters enqueued
+ */
+int uart_write_str(const char* s);
+
+/**
+ * @brief Enqueue an integer as a decimal string (lossless)
+ * @param[in] value Integer value to enqueue (full 32-bit range supported)
+ * @return Number of characters enqueued
+ */
+int uart_write_int(int value);
+
+/**
+ * @brief Enqueue a byte as two uppercase hexadecimal digits
+ * @param[in] b Byte to enqueue
+ * @return Number of characters enqueued (always 2)
+ */
+int uart_write_hex(uint8_t b);
+
+/**
+ * @brief Blocking drain of the USART1 TX ring buffer
+ * @note Waits until every enqueued byte has been shifted out (TC set).
+ *       Use once at startup so banners are never truncated.
+ */
+void uart_tx_flush(void);
+
+#endif // APP_H

--- a/inc/ds18b20.h
+++ b/inc/ds18b20.h
@@ -11,15 +11,15 @@
  * - Hardware timer-based timing with DMA for data capture
  * - Non-blocking state machine architecture
  * - Weak function callbacks for customization
- * - Optional blocking startup scan (ds18b20_search_devices) to enumerate
- *   all sensors on the bus and read their 64-bit ROM addresses
+ * - Low-level blocking primitives (ds18b20_reset, ds18b20_write_bit, etc.)
+ *   for custom 1-Wire protocols such as device search
  * 
  * Usage:
  * 1. Call ds18b20_init() once at startup
- * 2. (Optional) Call ds18b20_search_devices() to enumerate bus devices
- * 3. (Optional) Call ds18b20_select() to measure one specific device
- * 4. Call ds18b20_poll() repeatedly from main loop
- * 5. Implement weak callbacks ds18b20_busy() and ds18b20_complete()
+ * 2. Call ds18b20_poll() repeatedly from main loop
+ * 3. (Optional) Use low-level primitives for custom protocols; call
+ *    ds18b20_restore() before returning to poll()
+ * 4. Implement weak callbacks ds18b20_busy() and ds18b20_complete()
  *    to handle status indication and temperature results
  */
 
@@ -53,6 +53,96 @@ extern "C" {
 #define DS18B20_FAMILY_CODE 0x28
 
 /**
+ * @brief Standard 8 bits per byte
+ */
+#define DS18B20_BITS_PER_BYTE 8
+
+/**
+ * @brief Number of bytes in a device ROM address
+ */
+#define DS18B20_ROM_BYTES 8
+
+/**
+ * @brief DS18B20 Search ROM command
+ */
+#define DS18B20_SEARCH_ROM 0xF0
+
+/**
+ * @brief DS18B20 Match ROM command
+ */
+#define DS18B20_MATCH_ROM 0x55
+
+/**
+ * @brief DS18B20 Convert T command
+ */
+#define DS18B20_CONVERT_T 0x44
+
+/**
+ * @brief DS18B20 Read Scratchpad command
+ */
+#define DS18B20_READ_SCRATCHPAD 0xBE
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DS18B20_LowLevel Low-Level Blocking 1-Wire Primitives
+ * @brief Blocking primitives for custom 1-Wire protocols (e.g., device search).
+ * @warning These busy-wait on hardware completion. They use the same TIM1/DMA
+ *          as the non-blocking state machine and MUST NOT be called while
+ *          polling is active. After using these, call ds18b20_restore()
+ *          before starting ds18b20_poll().
+ * @{
+ */
+
+/**
+ * @brief Perform a blocking 1-Wire reset and check for a presence pulse
+ * @return 1 if at least one device answered the reset, 0 otherwise
+ */
+uint8_t ds18b20_reset(void);
+
+/**
+ * @brief Write one bit to the 1-Wire bus as a single hardware-timed slot
+ * @param[in] bit 1 = short low pulse (~5µs), 0 = long low pulse (~60µs)
+ */
+void ds18b20_write_bit(uint8_t bit);
+
+/**
+ * @brief Read one bit from the 1-Wire bus as a single hardware-timed slot
+ * @return The bit value read (0 or 1)
+ */
+uint8_t ds18b20_read_bit(void);
+
+/**
+ * @brief Write one byte to the 1-Wire bus, LSB first
+ * @param[in] byte Byte value to transmit
+ */
+void ds18b20_write_byte(uint8_t byte);
+
+/**
+ * @brief Read one byte from the 1-Wire bus, LSB first
+ * @return The byte value read
+ */
+uint8_t ds18b20_read_byte(void);
+
+/**
+ * @brief Restore the non-blocking state machine after using low-level primitives
+ * @note Call this after finishing low-level operations and before starting
+ *       ds18b20_poll(). It re-primes the state machine so the first poll()
+ *       begins a measurement cycle.
+ */
+void ds18b20_restore(void);
+
+/**
+ * @brief Calculate Dallas/Maxim CRC-8 over a byte buffer
+ * @param[in] data Input buffer
+ * @param[in] len Number of bytes to process
+ * @return CRC-8 checksum value
+ */
+uint8_t ds18b20_crc8(const uint8_t* data, uint8_t len);
+
+/**
  * @}
  */
 
@@ -69,35 +159,12 @@ void ds18b20_init(void);
 /**
  * @brief Advance the state machine (non-blocking)
  * @note Call periodically from main loop
- * 
+ *
  * This function implements the core non-blocking state machine that manages
  * the 1-Wire communication protocol with the DS18B20 sensor. It uses hardware
  * timer and DMA to handle timing-critical operations without software delays.
  */
 void ds18b20_poll(void);
-
-/**
- * @brief Enumerate all DS18B20 devices on the 1-Wire bus (blocking)
- * @param[in] sink Callback invoked once per found DS18B20 device with its
- *                 64-bit ROM address (LSB first). May be NULL to only count
- *                 devices. Return a non-zero value from the callback to stop
- *                 the search early; the device is still counted in the return
- *                 value.
- * @param[in] max_devices Maximum number of devices to report (0 aborts the
- *                        search and returns 0)
- * @return Number of DS18B20 devices found on the bus
- * @note BLOCKING function: it busy-waits on the timer update flag for the
- *       whole search (~15 ms per device). Intended for one-time use at startup
- *       before the main loop starts polling. It reuses the same hardware-timed
- *       1-Wire primitives as the state machine but does not touch the
- *       non-blocking measurement path. The Search ROM (0xF0) algorithm
- *       enumerates every 1-Wire device on the bus; only devices whose ROM
- *       family code is DS18B20_FAMILY_CODE (0x28) are reported, other devices
- *       are silently skipped. After the search, pass one of the reported ROM
- *       addresses to ds18b20_select() to measure that device; otherwise the
- *       measurement path keeps using Skip-ROM (single-sensor) addressing.
- */
-uint8_t ds18b20_search_devices(uint8_t (*sink)(const uint8_t* rom), uint8_t max_devices);
 
 /**
  * @brief Select which DS18B20 device to measure by its ROM address
@@ -106,7 +173,8 @@ uint8_t ds18b20_search_devices(uint8_t (*sink)(const uint8_t* rom), uint8_t max_
  * @note With a non-NULL address, the state machine sends Match ROM (0x55)
  *       plus the device address before each command, so only that device
  *       responds. Pass NULL to keep the legacy single-sensor Skip ROM
- *       behaviour. The address should come from ds18b20_search_devices().
+ *       behaviour. To measure a specific device, pass its ROM address
+ *       (e.g., from a bus search) to ds18b20_select().
  */
 void ds18b20_select(const uint8_t* rom);
 

--- a/inc/ds18b20.h
+++ b/inc/ds18b20.h
@@ -11,14 +11,18 @@
  * - Hardware timer-based timing with DMA for data capture
  * - Non-blocking state machine architecture
  * - Weak function callbacks for customization
- * - Low-level blocking primitives (ds18b20_reset, ds18b20_write_bit, etc.)
- *   for custom 1-Wire protocols such as device search
+ * - Built-in non-blocking device search (ds18b20_search_*) for multi-sensor
+ *   buses, with zero busy-waits
+ * 
+ * All low-level 1-Wire bus operations and the Search ROM state machine live
+ * inside the driver. The public interface is intentionally small: start and
+ * poll the driver, select a device, and (optionally) run a bus scan.
  * 
  * Usage:
  * 1. Call ds18b20_init() once at startup
  * 2. Call ds18b20_poll() repeatedly from main loop
- * 3. (Optional) Use low-level primitives for custom protocols; call
- *    ds18b20_restore() before returning to poll()
+ * 3. (Optional) Run the non-blocking device search (ds18b20_search_*) before
+ *    starting poll(); the search helper hands back to poll() automatically
  * 4. Implement weak callbacks ds18b20_busy() and ds18b20_complete()
  *    to handle status indication and temperature results
  */
@@ -53,94 +57,49 @@ extern "C" {
 #define DS18B20_FAMILY_CODE 0x28
 
 /**
- * @brief Standard 8 bits per byte
- */
-#define DS18B20_BITS_PER_BYTE 8
-
-/**
  * @brief Number of bytes in a device ROM address
  */
 #define DS18B20_ROM_BYTES 8
-
-/**
- * @brief DS18B20 Search ROM command
- */
-#define DS18B20_SEARCH_ROM 0xF0
-
-/**
- * @brief DS18B20 Match ROM command
- */
-#define DS18B20_MATCH_ROM 0x55
-
-/**
- * @brief DS18B20 Convert T command
- */
-#define DS18B20_CONVERT_T 0x44
-
-/**
- * @brief DS18B20 Read Scratchpad command
- */
-#define DS18B20_READ_SCRATCHPAD 0xBE
 
 /**
  * @}
  */
 
 /**
- * @defgroup DS18B20_LowLevel Low-Level Blocking 1-Wire Primitives
- * @brief Blocking primitives for custom 1-Wire protocols (e.g., device search).
- * @warning These busy-wait on hardware completion. They use the same TIM1/DMA
- *          as the non-blocking state machine and MUST NOT be called while
- *          polling is active. After using these, call ds18b20_restore()
- *          before starting ds18b20_poll().
+ * @defgroup DS18B20_Search DS18B20 Non-Blocking Device Search
+ * @brief Maxim Search ROM (0xF0) state machine, driven from the main loop
+ *        like the measurement state machine. It filters by family code,
+ *        validates the CRC and reports each found DS18B20 via a callback.
+ *        When the search finishes it hands the timer back to ds18b20_poll().
  * @{
  */
 
 /**
- * @brief Perform a blocking 1-Wire reset and check for a presence pulse
- * @return 1 if at least one device answered the reset, 0 otherwise
+ * @brief Callback invoked for every DS18B20 found by the search
+ * @param[in] rom Pointer to the 8-byte ROM address (LSB first)
+ * @return 0 to continue the search, non-zero to stop
+ * @note The pointer is only valid for the duration of the callback.
  */
-uint8_t ds18b20_reset(void);
+typedef uint8_t (*ds18b20_search_sink_t)(const uint8_t* rom);
 
 /**
- * @brief Write one bit to the 1-Wire bus as a single hardware-timed slot
- * @param[in] bit 1 = short low pulse (~5µs), 0 = long low pulse (~60µs)
+ * @brief Start a non-blocking device search
+ * @param[in] sink Callback invoked per found DS18B20 device (may be NULL)
+ * @param[in] max_devices Maximum number of devices to report (0 aborts)
  */
-void ds18b20_write_bit(uint8_t bit);
+void ds18b20_search_start(ds18b20_search_sink_t sink, uint8_t max_devices);
 
 /**
- * @brief Read one bit from the 1-Wire bus as a single hardware-timed slot
- * @return The bit value read (0 or 1)
+ * @brief Advance the non-blocking device search by one hardware operation
+ * @return 1 when the search is finished, 0 while still running
  */
-uint8_t ds18b20_read_bit(void);
+uint8_t ds18b20_search_poll(void);
 
 /**
- * @brief Write one byte to the 1-Wire bus, LSB first
- * @param[in] byte Byte value to transmit
+ * @brief Number of DS18B20 devices found (valid once the search finished)
+ * @return Count of found devices
  */
-void ds18b20_write_byte(uint8_t byte);
-
-/**
- * @brief Read one byte from the 1-Wire bus, LSB first
- * @return The byte value read
- */
-uint8_t ds18b20_read_byte(void);
-
-/**
- * @brief Restore the non-blocking state machine after using low-level primitives
- * @note Call this after finishing low-level operations and before starting
- *       ds18b20_poll(). It re-primes the state machine so the first poll()
- *       begins a measurement cycle.
- */
-void ds18b20_restore(void);
-
-/**
- * @brief Calculate Dallas/Maxim CRC-8 over a byte buffer
- * @param[in] data Input buffer
- * @param[in] len Number of bytes to process
- * @return CRC-8 checksum value
- */
-uint8_t ds18b20_crc8(const uint8_t* data, uint8_t len);
+uint8_t ds18b20_search_count(void);
 
 /**
  * @}

--- a/inc/ds18b20.h
+++ b/inc/ds18b20.h
@@ -7,15 +7,18 @@
  * 
  * Key features:
  * - Pure bare-metal, register-level programming
- * - No interrupts, no software delays, no busy-waits
+ * - No interrupts; no software delays or busy-waits in the measurement path
  * - Hardware timer-based timing with DMA for data capture
  * - Non-blocking state machine architecture
  * - Weak function callbacks for customization
+ * - Optional blocking startup scan (ds18b20_search_devices) to enumerate
+ *   all sensors on the bus and read their 64-bit ROM addresses
  * 
  * Usage:
  * 1. Call ds18b20_init() once at startup
- * 2. Call ds18b20_poll() repeatedly from main loop
- * 3. Implement weak callbacks ds18b20_busy() and ds18b20_complete()
+ * 2. (Optional) Call ds18b20_search_devices() to enumerate bus devices
+ * 3. Call ds18b20_poll() repeatedly from main loop
+ * 4. Implement weak callbacks ds18b20_busy() and ds18b20_complete()
  *    to handle status indication and temperature results
  */
 
@@ -64,6 +67,24 @@ void ds18b20_init(void);
  * timer and DMA to handle timing-critical operations without software delays.
  */
 void ds18b20_poll(void);
+
+/**
+ * @brief Enumerate all DS18B20 devices on the 1-Wire bus (blocking)
+ * @param[in] sink Callback invoked once per found device with its 64-bit ROM
+ *                 address (LSB first). May be NULL to only count devices.
+ *                 Return a non-zero value from the callback to stop the search
+ *                 early; the device is still counted in the return value.
+ * @param[in] max_devices Maximum number of devices to report (0 aborts the
+ *                        search and returns 0)
+ * @return Number of devices found on the bus
+ * @note BLOCKING function: it busy-waits on the timer update flag for the
+ *       whole search (~15 ms per device). Intended for one-time use at startup
+ *       before the main loop starts polling. It reuses the same hardware-timed
+ *       1-Wire primitives as the state machine but does not touch the
+ *       non-blocking measurement path, which continues to use Skip-ROM
+ *       (single-sensor) addressing.
+ */
+uint8_t ds18b20_search_devices(uint8_t (*sink)(const uint8_t* rom), uint8_t max_devices);
 
 /**
  * @brief Busy indicator callback (weak)

--- a/inc/ds18b20.h
+++ b/inc/ds18b20.h
@@ -46,6 +46,13 @@ extern "C" {
 #define DS18B20_TEMP_ERROR_CRC_FAIL (INT16_MIN + 2) /**< CRC checksum validation failed */
 
 /**
+ * @brief DS18B20 1-Wire family code (LSB of the 64-bit ROM address)
+ * @note Other 1-Wire devices on the bus use different family codes and are
+ *       skipped by the device search.
+ */
+#define DS18B20_FAMILY_CODE 0x28
+
+/**
  * @}
  */
 
@@ -71,21 +78,24 @@ void ds18b20_poll(void);
 
 /**
  * @brief Enumerate all DS18B20 devices on the 1-Wire bus (blocking)
- * @param[in] sink Callback invoked once per found device with its 64-bit ROM
- *                 address (LSB first). May be NULL to only count devices.
- *                 Return a non-zero value from the callback to stop the search
- *                 early; the device is still counted in the return value.
+ * @param[in] sink Callback invoked once per found DS18B20 device with its
+ *                 64-bit ROM address (LSB first). May be NULL to only count
+ *                 devices. Return a non-zero value from the callback to stop
+ *                 the search early; the device is still counted in the return
+ *                 value.
  * @param[in] max_devices Maximum number of devices to report (0 aborts the
  *                        search and returns 0)
- * @return Number of devices found on the bus
+ * @return Number of DS18B20 devices found on the bus
  * @note BLOCKING function: it busy-waits on the timer update flag for the
  *       whole search (~15 ms per device). Intended for one-time use at startup
  *       before the main loop starts polling. It reuses the same hardware-timed
  *       1-Wire primitives as the state machine but does not touch the
- *       non-blocking measurement path. After the search, pass one of the
- *       reported ROM addresses to ds18b20_select() to measure that device;
- *       otherwise the measurement path keeps using Skip-ROM (single-sensor)
- *       addressing.
+ *       non-blocking measurement path. The Search ROM (0xF0) algorithm
+ *       enumerates every 1-Wire device on the bus; only devices whose ROM
+ *       family code is DS18B20_FAMILY_CODE (0x28) are reported, other devices
+ *       are silently skipped. After the search, pass one of the reported ROM
+ *       addresses to ds18b20_select() to measure that device; otherwise the
+ *       measurement path keeps using Skip-ROM (single-sensor) addressing.
  */
 uint8_t ds18b20_search_devices(uint8_t (*sink)(const uint8_t* rom), uint8_t max_devices);
 

--- a/inc/ds18b20.h
+++ b/inc/ds18b20.h
@@ -17,8 +17,9 @@
  * Usage:
  * 1. Call ds18b20_init() once at startup
  * 2. (Optional) Call ds18b20_search_devices() to enumerate bus devices
- * 3. Call ds18b20_poll() repeatedly from main loop
- * 4. Implement weak callbacks ds18b20_busy() and ds18b20_complete()
+ * 3. (Optional) Call ds18b20_select() to measure one specific device
+ * 4. Call ds18b20_poll() repeatedly from main loop
+ * 5. Implement weak callbacks ds18b20_busy() and ds18b20_complete()
  *    to handle status indication and temperature results
  */
 
@@ -81,10 +82,23 @@ void ds18b20_poll(void);
  *       whole search (~15 ms per device). Intended for one-time use at startup
  *       before the main loop starts polling. It reuses the same hardware-timed
  *       1-Wire primitives as the state machine but does not touch the
- *       non-blocking measurement path, which continues to use Skip-ROM
- *       (single-sensor) addressing.
+ *       non-blocking measurement path. After the search, pass one of the
+ *       reported ROM addresses to ds18b20_select() to measure that device;
+ *       otherwise the measurement path keeps using Skip-ROM (single-sensor)
+ *       addressing.
  */
 uint8_t ds18b20_search_devices(uint8_t (*sink)(const uint8_t* rom), uint8_t max_devices);
+
+/**
+ * @brief Select which DS18B20 device to measure by its ROM address
+ * @param[in] rom Pointer to the 8-byte ROM address (LSB first), or NULL to
+ *                return to Skip ROM (broadcast) addressing
+ * @note With a non-NULL address, the state machine sends Match ROM (0x55)
+ *       plus the device address before each command, so only that device
+ *       responds. Pass NULL to keep the legacy single-sensor Skip ROM
+ *       behaviour. The address should come from ds18b20_search_devices().
+ */
+void ds18b20_select(const uint8_t* rom);
 
 /**
  * @brief Busy indicator callback (weak)

--- a/src/app.c
+++ b/src/app.c
@@ -28,35 +28,37 @@ void uart_poll_tx(void) {
 }
 
 /**
- * @brief Enqueue a single byte into the UART transmit buffer (lossless)
+ * @brief Enqueue a single byte into the UART transmit buffer (non-blocking)
  * @param[in] b Byte to enqueue
- * @note Blocks only while the buffer is full, polling uart_poll_tx() to make
- *       room - a byte is never dropped
+ * @return 1 if enqueued, 0 if the buffer is full (byte dropped)
+ * @note Never blocks: when the buffer is full the byte is dropped so the
+ *       caller's code path stays non-blocking.
  */
-void uart_tx_enqueue_byte(uint8_t b) {
-    for (;;) {
-        uint8_t head = uart_tx_head;
-        // Calculate next head position with wrap-around using power-of-two mask
-        uint8_t next = (uint8_t)((head + 1u) & UART_TX_IDX_MASK);
-        if (next != uart_tx_tail) { // Room is available
-            uart_tx_buf[head] = b; // Store byte at current head position
-            uart_tx_head = next; // Update head pointer
-            return;
-        }
-        uart_poll_tx(); // Make room by feeding one byte to the UART
+uint8_t uart_tx_enqueue_byte(uint8_t b) {
+    uint8_t head = uart_tx_head;
+    // Calculate next head position with wrap-around using power-of-two mask
+    uint8_t next = (uint8_t)((head + 1u) & UART_TX_IDX_MASK);
+    if (next != uart_tx_tail) { // Room is available
+        uart_tx_buf[head] = b; // Store byte at current head position
+        uart_tx_head = next; // Update head pointer
+        return 1;
     }
+    return 0; // Buffer full - drop the byte to stay non-blocking
 }
 
 /**
- * @brief Enqueue an entire null-terminated string (lossless)
+ * @brief Enqueue an entire null-terminated string (non-blocking)
  * @param[in] s Null-terminated string to enqueue
- * @return Number of characters enqueued
+ * @return Number of characters actually enqueued (may be less than strlen)
  */
 int uart_write_str(const char* s) {
     const char* start = s;
     while (*s) {
-        uart_tx_enqueue_byte((uint8_t)*s);
-        s++;
+        if (uart_tx_enqueue_byte((uint8_t)*s)) {
+            s++;
+        } else {
+            break; // Buffer full - stop to stay non-blocking
+        }
     }
     return (int)(s - start);
 }
@@ -96,29 +98,14 @@ int uart_write_int(int value) {
 }
 
 /**
- * @brief Enqueue one byte as two uppercase hexadecimal digits
+ * @brief Enqueue one byte as two uppercase hexadecimal digits (non-blocking)
  * @param[in] b Byte to convert and transmit
- * @return Number of characters enqueued (always 2)
+ * @return Number of characters actually enqueued (0, 1 or 2)
  */
 int uart_write_hex(uint8_t b) {
     static const char hex[] = "0123456789ABCDEF";
-    uart_tx_enqueue_byte((uint8_t)hex[(b >> 4) & 0x0F]);
-    uart_tx_enqueue_byte((uint8_t)hex[b & 0x0F]);
-    return 2;
-}
-
-/**
- * @brief Blocking drain of the UART TX ring buffer
- * @note Waits until every enqueued byte has been shifted out (TC set).
- *       Call once at startup so the banner is never truncated.
- */
-void uart_tx_flush(void) {
-    while (uart_tx_tail != uart_tx_head) {
-        uart_poll_tx();
-    }
-    while (!(USART1->SR & USART_SR_TC)) {
-        ;
-    }
+    return (int)uart_tx_enqueue_byte((uint8_t)hex[(b >> 4) & 0x0F]) +
+           (int)uart_tx_enqueue_byte((uint8_t)hex[b & 0x0F]);
 }
 
 /**

--- a/src/app.c
+++ b/src/app.c
@@ -1,0 +1,207 @@
+/**
+ * @file app.c
+ * @brief Shared application layer implementation (UART TX, system clock, LED)
+ */
+
+#include "app.h"
+#include "stm32f1xx.h"
+
+// ======== USART1 TX ring buffer ========
+static uint8_t uart_tx_head = 0; // write index - points to next free slot
+static uint8_t uart_tx_tail = 0; // read index - points to oldest data
+static uint8_t uart_tx_buf[UART_TX_BUF_SIZE]; // circular buffer for UART transmission
+
+/**
+ * @brief Advance UART transmission by at most one byte (non-blocking)
+ * @note Must be called periodically to feed UART hardware from the buffer
+ */
+void uart_poll_tx(void) {
+    // Check if UART is ready to transmit (TXE flag set) and buffer not empty
+    if ((USART1->SR & USART_SR_TXE) && (uart_tx_tail != uart_tx_head)) {
+        // Get byte from buffer at tail position
+        uint8_t b = uart_tx_buf[uart_tx_tail];
+        // Advance tail pointer with wrap-around
+        uart_tx_tail = (uint8_t)((uart_tx_tail + 1u) & UART_TX_IDX_MASK);
+        // Write byte to UART data register for transmission
+        USART1->DR = b;
+    }
+}
+
+/**
+ * @brief Enqueue a single byte into the UART transmit buffer (lossless)
+ * @param[in] b Byte to enqueue
+ * @note Blocks only while the buffer is full, polling uart_poll_tx() to make
+ *       room - a byte is never dropped
+ */
+void uart_tx_enqueue_byte(uint8_t b) {
+    for (;;) {
+        uint8_t head = uart_tx_head;
+        // Calculate next head position with wrap-around using power-of-two mask
+        uint8_t next = (uint8_t)((head + 1u) & UART_TX_IDX_MASK);
+        if (next != uart_tx_tail) { // Room is available
+            uart_tx_buf[head] = b; // Store byte at current head position
+            uart_tx_head = next; // Update head pointer
+            return;
+        }
+        uart_poll_tx(); // Make room by feeding one byte to the UART
+    }
+}
+
+/**
+ * @brief Enqueue an entire null-terminated string (lossless)
+ * @param[in] s Null-terminated string to enqueue
+ * @return Number of characters enqueued
+ */
+int uart_write_str(const char* s) {
+    const char* start = s;
+    while (*s) {
+        uart_tx_enqueue_byte((uint8_t)*s);
+        s++;
+    }
+    return (int)(s - start);
+}
+
+/**
+ * @brief Convert integer to string and enqueue for UART transmission
+ * @param[in] value Integer value to convert and transmit
+ * @return Number of characters enqueued
+ * @note Buffer holds 12 chars, enough for the full int32 range (-2147483648)
+ */
+int uart_write_int(int value) {
+    char buf[12]; // enough for -2147483648 and '\0'
+    char* p = buf + sizeof(buf) - 1;
+    *p = '\0';
+
+    if (value == 0) { // Special case for zero
+        *(--p) = '0';
+    } else {
+        int is_negative = 0;
+        unsigned int uvalue;
+
+        if (value < 0) { // Handle negative numbers
+            is_negative = 1;
+            uvalue = (unsigned int)-(value + 1) + 1;
+        } else {
+            uvalue = (unsigned int)value;
+        }
+
+        do { // Convert digits from least significant to most significant
+            *(--p) = '0' + (uvalue % 10);
+            uvalue /= 10;
+        } while (uvalue);
+
+        if (is_negative) *(--p) = '-'; // Add negative sign if needed
+    }
+    return uart_write_str(p);
+}
+
+/**
+ * @brief Enqueue one byte as two uppercase hexadecimal digits
+ * @param[in] b Byte to convert and transmit
+ * @return Number of characters enqueued (always 2)
+ */
+int uart_write_hex(uint8_t b) {
+    static const char hex[] = "0123456789ABCDEF";
+    uart_tx_enqueue_byte((uint8_t)hex[(b >> 4) & 0x0F]);
+    uart_tx_enqueue_byte((uint8_t)hex[b & 0x0F]);
+    return 2;
+}
+
+/**
+ * @brief Blocking drain of the UART TX ring buffer
+ * @note Waits until every enqueued byte has been shifted out (TC set).
+ *       Call once at startup so the banner is never truncated.
+ */
+void uart_tx_flush(void) {
+    while (uart_tx_tail != uart_tx_head) {
+        uart_poll_tx();
+    }
+    while (!(USART1->SR & USART_SR_TC)) {
+        ;
+    }
+}
+
+/**
+ * @brief Configure system clock (72MHz via HSE+PLL, or skip for HSI 8MHz)
+ */
+__STATIC_FORCEINLINE void configure_system_clock(void) {
+#ifndef HSI_8MHZ
+    // Enable HSI and HSE oscillators
+    RCC->CR = RCC_CR_HSION | RCC_CR_HSEON;
+    // Wait for HSE to stabilize - HSERDY is the hardware stabilization
+    // indicator, so no fixed delay is required
+    while (!(RCC->CR & RCC_CR_HSERDY))
+        ;
+    // Configure PLL: HSE source, multiply by 9, APB1 prescaler /2
+    RCC->CFGR = RCC_CFGR_PLLSRC | RCC_CFGR_PLLMULL9 | RCC_CFGR_PPRE1_DIV2;
+    // Enable PLL only after HSE is confirmed stable, so the PLL locks on a
+    // valid clock (per RM0008: HSE must be ready before enabling the PLL)
+    RCC->CR |= RCC_CR_PLLON;
+    // Wait for the PLL to lock
+    while (!(RCC->CR & RCC_CR_PLLRDY))
+        ;
+    // Configure flash latency for 72MHz operation
+    FLASH->ACR = FLASH_ACR_PRFTBE | FLASH_ACR_LATENCY_2;
+    // Switch system clock to PLL
+    RCC->CFGR = RCC_CFGR_PLLSRC | RCC_CFGR_PLLMULL9 | RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_SW_PLL;
+    // Wait for system clock switch to PLL
+    while ((RCC->CFGR & RCC_CFGR_SWS_PLL) != RCC_CFGR_SWS_PLL)
+        ;
+    // Disable HSI oscillator
+    RCC->CR &= ~RCC_CR_HSION;
+#endif
+    // HSI_8MHZ: MCU already runs on HSI 8MHz after reset — nothing to configure
+}
+
+/**
+ * @brief Initialize microcontroller peripherals for UART communication and LED control
+ */
+__STATIC_FORCEINLINE void hardware_init(void) {
+
+    // Enable clock for GPIOA, USART1, and GPIOC peripherals
+    RCC->APB2ENR |= (RCC_APB2ENR_IOPAEN | RCC_APB2ENR_USART1EN | RCC_APB2ENR_IOPCEN);
+
+    // Configure PA9 as alternate function push-pull output, 2MHz speed
+    // Clear existing configuration bits
+    GPIOA->CRH &= ~(GPIO_CRH_MODE9 | GPIO_CRH_CNF9);
+    // Set alternate function push-pull output mode, 2MHz speed
+    GPIOA->CRH |= (GPIO_CRH_MODE9_1 | GPIO_CRH_CNF9_1);
+
+    // Configure PC13 as general purpose output, 2MHz speed for LED control
+    GPIOC->CRH &= ~(GPIO_CRH_MODE13 | GPIO_CRH_CNF13);
+    GPIOC->CRH |= GPIO_CRH_MODE13_1;
+
+    // Configure USART1: 115200 baud, 8 data bits, no parity, 1 stop bit, TX only
+#ifdef HSI_8MHZ
+    USART1->BRR = USART_BRR_CALC(8000000, 115200); // PCLK2=8MHz
+#else
+    USART1->BRR = USART_BRR_CALC(72000000, 115200); // PCLK2=72MHz
+#endif
+    USART1->CR1 = USART_CR1_TE | USART_CR1_UE; // Enable USART1; TX enable only
+}
+
+/**
+ * @brief Initialize system clock, USART1 TX and the busy LED GPIO
+ */
+void app_init(void) {
+    configure_system_clock();
+    hardware_init();
+}
+
+/**
+ * @brief Busy indicator - toggles LED during measurement
+ * @param[in] action 0 = idle, non-zero = busy
+ * @note Non-blocking LED control using atomic BSRR register operations.
+ *       Strong definition overrides the weak one in the DS18B20 driver.
+ */
+void ds18b20_busy(unsigned action) {
+    if (action) {
+        // Turn LED on (PC13 low due to pull-up LED configuration)
+        // BSRR BR register: atomic bit reset operation
+        GPIOC->BSRR = GPIO_BSRR_BR13;
+    } else {
+        // Turn LED off (PC13 high)
+        // BSRR BS register: atomic bit set operation
+        GPIOC->BSRR = GPIO_BSRR_BS13;
+    }
+}

--- a/src/demo.c
+++ b/src/demo.c
@@ -3,7 +3,11 @@
 
 // ======== Config: printing buffer size (power of two) ========
 #ifndef UART_TX_BUF_SIZE
-#define UART_TX_BUF_SIZE 128u // set to 128 or 256 as desired
+#define UART_TX_BUF_SIZE 256u // set to 128 or 256 as desired
+#endif
+// ======== Config: maximum devices reported by the startup bus scan ========
+#ifndef DS18B20_SEARCH_MAX_DEVICES
+#define DS18B20_SEARCH_MAX_DEVICES 8u
 #endif
 
 // Validate that buffer size is a power of two for efficient masking operations
@@ -178,6 +182,49 @@ __STATIC_FORCEINLINE void uart_write_int(int value) {
 }
 
 /**
+ * @brief Enqueue one byte as two uppercase hexadecimal digits (best-effort)
+ * @param[in] b Byte to convert and transmit
+ */
+__STATIC_FORCEINLINE void uart_write_hex(uint8_t b) {
+    static const char hex[] = "0123456789ABCDEF";
+    (void)uart_tx_enqueue_byte((uint8_t)hex[(b >> 4) & 0x0F]);
+    (void)uart_tx_enqueue_byte((uint8_t)hex[b & 0x0F]);
+}
+
+/**
+ * @brief Device search callback - prints the 64-bit ROM address in hex
+ * @param[in] rom Pointer to the 8-byte ROM address (LSB first)
+ * @return 0 to continue the search
+ */
+static uint8_t device_found_sink(const uint8_t* rom) {
+    uart_write_str("  ROM: ");
+    for (uint8_t i = 0; i < 8; i++) {
+        uart_write_hex(rom[i]);
+        if (i != 7) (void)uart_tx_enqueue_byte(' ');
+    }
+    uart_write_str("\r\n");
+    return 0;
+}
+
+/**
+ * @brief Run the blocking bus scan once at startup and report the result
+ * @note The output is enqueued into the UART ring buffer; it is flushed by
+ *       uart_poll_tx() once the main loop starts. Up to ~5 devices fit in
+ *       the buffer before the output is truncated (best-effort).
+ */
+__STATIC_FORCEINLINE void search_devices_and_report(void) {
+    uart_write_str("Searching 1-Wire bus...\r\n");
+    uint8_t count = ds18b20_search_devices(device_found_sink, DS18B20_SEARCH_MAX_DEVICES);
+    if (count == 0) {
+        uart_write_str("No devices on the 1-Wire bus.\r\n");
+    } else {
+        uart_write_str("Found ");
+        uart_write_int(count);
+        uart_write_str(" device(s).\r\n");
+    }
+}
+
+/**
  * @brief Weak implementation for DS18B20 measurement completion callback - handles result display
  * @param[in] temp Temperature value in tenths of degrees Celsius, or error code
  */
@@ -216,6 +263,7 @@ int main(void) {
     hardware_init(); // Initialize hardware peripherals (non-blocking)
     uart_write_str("DS18B20 demo starting...\r\n"); // Enqueue startup message to UART buffer
     ds18b20_init(); // Initialize DS18B20 driver (non-blocking)
+    search_devices_and_report(); // Blocking one-time bus scan (all sensors)
 
     for (;;) { // Main event loop (non-blocking, cooperative multitasking)
 

--- a/src/demo.c
+++ b/src/demo.c
@@ -1,186 +1,12 @@
-#include "ds18b20.h"
-#include "stm32f1xx.h"
-
-// ======== Config: printing buffer size (power of two) ========
-#ifndef UART_TX_BUF_SIZE
-#define UART_TX_BUF_SIZE 128u // set to 128 or 256 as desired
-#endif
-
-// Validate that buffer size is a power of two for efficient masking operations
-#if (UART_TX_BUF_SIZE & (UART_TX_BUF_SIZE - 1u)) != 0
-#error "UART_TX_BUF_SIZE must be a power of two (e.g., 32, 64, 128, 256)."
-#endif
-
-// Create mask for buffer index wrapping (power of two optimization)
-#define UART_TX_IDX_MASK (UART_TX_BUF_SIZE - 1u)
-// Calculate baud rate register value with rounding for accuracy
-#define USART_BRR_CALC(PCLK, BAUD) (((PCLK) + ((BAUD) / 2)) / (BAUD))
-
-// ======== USART1 TX ring buffer ========
-static uint8_t uart_tx_head = 0; // write index - points to next free slot
-static uint8_t uart_tx_tail = 0; // read index - points to oldest data
-static uint8_t uart_tx_buf[UART_TX_BUF_SIZE]; // circular buffer for UART transmission
-
 /**
- * @brief Non-blocking function to enqueue a single byte into the UART transmit buffer
- * @param[in] b Byte to enqueue
- * @return 1 on success, 0 if buffer full
- * @note Returns immediately without blocking
+ * @file demo.c
+ * @brief Single-sensor example: one DS18B20, Skip ROM addressing
+ * 
+ * Demonstrates the basic measurement flow of the non-blocking driver.
+ * The shared platform layer (app.h/app.c) hides the UART and clock setup.
  */
-__STATIC_FORCEINLINE int uart_tx_enqueue_byte(uint8_t b) {
-    uint8_t head = uart_tx_head;
-    // Calculate next head position with wrap-around using power-of-two mask
-    uint8_t next = (uint8_t)((head + 1u) & UART_TX_IDX_MASK);
-    if (next == uart_tx_tail) { // Check if buffer is full
-        return 0; // Buffer full - non-blocking return
-    }
 
-    uart_tx_buf[head] = b; // Store byte at current head position
-    uart_tx_head = next; // Atomically update head pointer
-    return 1; // Success
-}
-
-/**
- * @brief Non-blocking function to enqueue entire null-terminated string into UART transmit buffer
- * @param[in] s Null-terminated string to enqueue
- * @return Number of characters successfully enqueued
- */
-__STATIC_FORCEINLINE int uart_write_str(const char* s) {
-    const char* start = s;
-    // Process each character until null terminator
-    while (*s) {
-        // Try to enqueue current character, break on buffer full (non-blocking)
-        if (!uart_tx_enqueue_byte((uint8_t)*s)) break;
-        s++;
-    }
-    // Return count of successfully enqueued characters
-    return (int)(s - start);
-}
-
-/**
- * @brief Non-blocking function to advance UART transmission by at most one byte
- * @note Must be called periodically to feed UART hardware from buffer
- * @note Returns immediately without blocking
- */
-__STATIC_FORCEINLINE void uart_poll_tx(void) {
-    // Check if UART is ready to transmit (TXE flag set) and buffer not empty
-    if ((USART1->SR & USART_SR_TXE) && (uart_tx_tail != uart_tx_head)) {
-        // Get byte from buffer at tail position
-        uint8_t b = uart_tx_buf[uart_tx_tail];
-        // Advance tail pointer with wrap-around
-        uart_tx_tail = (uint8_t)((uart_tx_tail + 1u) & UART_TX_IDX_MASK);
-        // Write byte to UART data register for transmission
-        USART1->DR = b;
-    }
-}
-
-/**
- * @brief Configure system clock (72MHz via HSE+PLL, or skip for HSI 8MHz)
- */
-__STATIC_FORCEINLINE void configure_system_clock(void) {
-#ifndef HSI_8MHZ
-    // Enable HSI and HSE oscillators
-    RCC->CR = RCC_CR_HSION | RCC_CR_HSEON;
-    // Wait for HSE to stabilize - HSERDY is the hardware stabilization
-    // indicator, so no fixed delay is required
-    while (!(RCC->CR & RCC_CR_HSERDY))
-        ;
-    // Configure PLL: HSE source, multiply by 9, APB1 prescaler /2
-    RCC->CFGR = RCC_CFGR_PLLSRC | RCC_CFGR_PLLMULL9 | RCC_CFGR_PPRE1_DIV2;
-    // Enable PLL only after HSE is confirmed stable, so the PLL locks on a
-    // valid clock (per RM0008: HSE must be ready before enabling the PLL)
-    RCC->CR |= RCC_CR_PLLON;
-    // Wait for the PLL to lock
-    while (!(RCC->CR & RCC_CR_PLLRDY))
-        ;
-    // Configure flash latency for 72MHz operation
-    FLASH->ACR = FLASH_ACR_PRFTBE | FLASH_ACR_LATENCY_2;
-    // Switch system clock to PLL
-    RCC->CFGR = RCC_CFGR_PLLSRC | RCC_CFGR_PLLMULL9 | RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_SW_PLL;
-    // Wait for system clock switch to PLL
-    while ((RCC->CFGR & RCC_CFGR_SWS_PLL) != RCC_CFGR_SWS_PLL)
-        ;
-    // Disable HSI oscillator
-    RCC->CR &= ~RCC_CR_HSION;
-#endif
-    // HSI_8MHZ: MCU already runs on HSI 8MHz after reset — nothing to configure
-}
-
-/**
- * @brief Initialize microcontroller peripherals for UART communication and LED control
- */
-__STATIC_FORCEINLINE void hardware_init(void) {
-
-    // Enable clock for GPIOA, USART1, and GPIOC peripherals
-    RCC->APB2ENR |= (RCC_APB2ENR_IOPAEN | RCC_APB2ENR_USART1EN | RCC_APB2ENR_IOPCEN);
-
-    // Configure PA9 as alternate function push-pull output, 2MHz speed
-    // Clear existing configuration bits
-    GPIOA->CRH &= ~(GPIO_CRH_MODE9 | GPIO_CRH_CNF9);
-    // Set alternate function push-pull output mode, 2MHz speed
-    GPIOA->CRH |= (GPIO_CRH_MODE9_1 | GPIO_CRH_CNF9_1);
-
-    // Configure PC13 as general purpose output, 2MHz speed for LED control
-    GPIOC->CRH &= ~(GPIO_CRH_MODE13 | GPIO_CRH_CNF13);
-    GPIOC->CRH |= GPIO_CRH_MODE13_1;
-
-    // Configure USART1: 115200 baud, 8 data bits, no parity, 1 stop bit, TX only
-#ifdef HSI_8MHZ
-    USART1->BRR = USART_BRR_CALC(8000000, 115200); // PCLK2=8MHz
-#else
-    USART1->BRR = USART_BRR_CALC(72000000, 115200); // PCLK2=72MHz
-#endif
-    USART1->CR1 = USART_CR1_TE | USART_CR1_UE; // Enable USART1; TX enable only
-}
-
-/**
- * @brief Busy indicator - toggles LED during measurement
- * @param[in] action 0 = idle, non-zero = busy
- * @note Non-blocking LED control using atomic BSRR register operations
- */
-void ds18b20_busy(unsigned action) {
-    if (action) {
-        // Turn LED on (PC13 low due to pull-up LED configuration)
-        // BSRR BR register: atomic bit reset operation
-        GPIOC->BSRR = GPIO_BSRR_BR13;
-    } else {
-        // Turn LED off (PC13 high)
-        // BSRR BS register: atomic bit set operation
-        GPIOC->BSRR = GPIO_BSRR_BS13;
-    }
-}
-
-/**
- * @brief Convert integer to string and enqueue for UART transmission
- * @param[in] value Integer value to convert and transmit
- */
-__STATIC_FORCEINLINE void uart_write_int(int value) {
-    char buf[7]; // enough for -32768 and '\0'
-    char* p = buf + sizeof(buf) - 1;
-    *p = '\0';
-
-    if (value == 0) { // Special case for zero
-        *(--p) = '0';
-    } else {
-        int is_negative = 0;
-        unsigned int uvalue;
-
-        if (value < 0) { // Handle negative numbers
-            is_negative = 1;
-            uvalue = (unsigned int)-(value + 1) + 1;
-        } else {
-            uvalue = value;
-        }
-
-        do { // Convert digits from least significant to most significant
-            *(--p) = '0' + (uvalue % 10);
-            uvalue /= 10;
-        } while (uvalue);
-
-        if (is_negative) *(--p) = '-'; // Add negative sign if needed
-    }
-    (void)uart_write_str(p); // best-effort enqueue to UART buffer
-}
+#include "app.h"
 
 /**
  * @brief Weak implementation for DS18B20 measurement completion callback - handles result display
@@ -216,10 +42,11 @@ void ds18b20_complete(int16_t temp) {
  */
 int main(void) {
 
-    configure_system_clock(); // Configure system clock for MCU
+    app_init(); // System clock, UART and LED GPIO - single setup call
 
-    hardware_init(); // Initialize hardware peripherals (non-blocking)
-    uart_write_str("DS18B20 demo starting...\r\n"); // Enqueue startup message to UART buffer
+    uart_write_str("DS18B20 demo starting...\r\n"); // Enqueue startup message
+    uart_tx_flush(); // Block until the banner is fully transmitted
+
     ds18b20_init(); // Initialize DS18B20 driver (non-blocking)
 
     for (;;) { // Main event loop (non-blocking, cooperative multitasking)

--- a/src/demo.c
+++ b/src/demo.c
@@ -10,6 +10,11 @@
 #define DS18B20_SEARCH_MAX_DEVICES 8u
 #endif
 
+// ======== Selected device state (round-robin measurement) ========
+static uint8_t found_roms[DS18B20_SEARCH_MAX_DEVICES][8]; // ROMs found at startup
+static uint8_t found_count = 0; // how many devices were found
+static uint8_t select_index = 0; // index of the currently selected device
+
 // Validate that buffer size is a power of two for efficient masking operations
 #if (UART_TX_BUF_SIZE & (UART_TX_BUF_SIZE - 1u)) != 0
 #error "UART_TX_BUF_SIZE must be a power of two (e.g., 32, 64, 128, 256)."
@@ -192,11 +197,17 @@ __STATIC_FORCEINLINE void uart_write_hex(uint8_t b) {
 }
 
 /**
- * @brief Device search callback - prints the 64-bit ROM address in hex
+ * @brief Device search callback - stores the ROM and prints it in hex
  * @param[in] rom Pointer to the 8-byte ROM address (LSB first)
  * @return 0 to continue the search
  */
 static uint8_t device_found_sink(const uint8_t* rom) {
+    if (found_count < DS18B20_SEARCH_MAX_DEVICES) {
+        for (uint8_t i = 0; i < 8; i++) {
+            found_roms[found_count][i] = rom[i];
+        }
+        found_count++;
+    }
     uart_write_str("  ROM: ");
     for (uint8_t i = 0; i < 8; i++) {
         uart_write_hex(rom[i]);
@@ -221,7 +232,26 @@ __STATIC_FORCEINLINE void search_devices_and_report(void) {
         uart_write_str("Found ");
         uart_write_int(count);
         uart_write_str(" device(s).\r\n");
+        select_index = 0;
+        ds18b20_select(found_roms[select_index]);
+        if (count == 1) {
+            uart_write_str("Measuring the single device.\r\n");
+        } else {
+            uart_write_str("Measuring devices in turn.\r\n");
+        }
     }
+}
+
+/**
+ * @brief Print the ROM address of the currently selected device (best-effort)
+ */
+__STATIC_FORCEINLINE void print_selected_rom(void) {
+    uart_write_str(" -> ");
+    for (uint8_t i = 0; i < 8; i++) {
+        uart_write_hex(found_roms[select_index][i]);
+        if (i != 7) (void)uart_tx_enqueue_byte(' ');
+    }
+    uart_write_str("\r\n");
 }
 
 /**
@@ -249,6 +279,13 @@ void ds18b20_complete(int16_t temp) {
         uart_write_int(frac); // Display fractional part
         uart_write_str(" C"); // Units
         uart_write_str("\r\n"); // And newline
+    }
+
+    // Round-robin: switch to the next device for the next measurement cycle
+    if (found_count > 1) {
+        select_index = (uint8_t)((select_index + 1u) % found_count);
+        ds18b20_select(found_roms[select_index]);
+        print_selected_rom();
     }
 }
 

--- a/src/demo.c
+++ b/src/demo.c
@@ -45,7 +45,6 @@ int main(void) {
     app_init(); // System clock, UART and LED GPIO - single setup call
 
     uart_write_str("DS18B20 demo starting...\r\n"); // Enqueue startup message
-    uart_tx_flush(); // Block until the banner is fully transmitted
 
     ds18b20_init(); // Initialize DS18B20 driver (non-blocking)
 

--- a/src/demo.c
+++ b/src/demo.c
@@ -81,12 +81,17 @@ __STATIC_FORCEINLINE void configure_system_clock(void) {
 #ifndef HSI_8MHZ
     // Enable HSI and HSE oscillators
     RCC->CR = RCC_CR_HSION | RCC_CR_HSEON;
+    // Wait for HSE to stabilize - HSERDY is the hardware stabilization
+    // indicator, so no fixed delay is required
+    while (!(RCC->CR & RCC_CR_HSERDY))
+        ;
     // Configure PLL: HSE source, multiply by 9, APB1 prescaler /2
     RCC->CFGR = RCC_CFGR_PLLSRC | RCC_CFGR_PLLMULL9 | RCC_CFGR_PPRE1_DIV2;
-    // Enable PLL
-    RCC->CR = RCC_CR_HSION | RCC_CR_HSEON | RCC_CR_PLLON;
-    // Wait for PLL and HSE ready flags
-    while ((RCC_CR_PLLRDY | RCC_CR_HSERDY) != (RCC->CR & (RCC_CR_PLLRDY | RCC_CR_HSERDY)))
+    // Enable PLL only after HSE is confirmed stable, so the PLL locks on a
+    // valid clock (per RM0008: HSE must be ready before enabling the PLL)
+    RCC->CR |= RCC_CR_PLLON;
+    // Wait for the PLL to lock
+    while (!(RCC->CR & RCC_CR_PLLRDY))
         ;
     // Configure flash latency for 72MHz operation
     FLASH->ACR = FLASH_ACR_PRFTBE | FLASH_ACR_LATENCY_2;

--- a/src/demo2.c
+++ b/src/demo2.c
@@ -1,15 +1,19 @@
 /**
  * @file demo2.c
- * @brief Multi-sensor example: startup bus scan + round-robin polling
+ * @brief Multi-sensor example: non-blocking bus scan + round-robin polling
  *
  * Demonstrates a Maxim 1-Wire Search ROM bus scan using the driver's
- * low-level blocking primitives (ds18b20_reset, ds18b20_write_bit,
- * ds18b20_read_bit, ds18b20_crc8), then ds18b20_select() to measure each
- * sensor in turn. The shared platform layer (app.h/app.c) hides the UART and
- * clock setup.
+ * non-blocking device search (ds18b20_search_*), then ds18b20_select() to
+ * measure each sensor in turn. All low-level bus operations and the search
+ * state machine live inside the driver; the example only uses the public
+ * high-level interface. Nothing in this example blocks: the search advances
+ * by one hardware operation per ds18b20_search_poll() call from the main
+ * loop. The shared platform layer (app.h/app.c) hides the UART and clock
+ * setup.
  */
 
 #include "app.h"
+#include "ds18b20.h"
 
 // ======== Config: maximum devices reported by the startup bus scan ========
 #ifndef DS18B20_SEARCH_MAX_DEVICES
@@ -20,153 +24,43 @@
 static uint8_t found_roms[DS18B20_SEARCH_MAX_DEVICES][8]; // ROMs found at startup
 static uint8_t found_count = 0; // how many devices were found
 static uint8_t select_index = 0; // index of the currently selected device
+static uint8_t search_running = 1; // 1 until the non-blocking bus scan finishes
 
 /**
  * @brief Device search callback - stores the ROM and prints it in hex
  * @param[in] rom Pointer to the 8-byte ROM address (LSB first)
  * @return 0 to continue the search
+ * @note Only DS18B20 devices reach this callback; the search module filters
+ *       by family code and enforces the device count limit.
  */
 static uint8_t device_found_sink(const uint8_t* rom) {
-    const uint8_t is_ds18b20 = (rom[0] == DS18B20_FAMILY_CODE);
-    if (is_ds18b20 && found_count < DS18B20_SEARCH_MAX_DEVICES) {
-        for (uint8_t i = 0; i < 8; i++) {
-            found_roms[found_count][i] = rom[i];
-        }
-        found_count++;
+    for (uint8_t i = 0; i < DS18B20_ROM_BYTES; i++) {
+        found_roms[found_count][i] = rom[i];
     }
+    found_count++;
     uart_write_str("  ROM: ");
-    for (uint8_t i = 0; i < 8; i++) {
+    for (uint8_t i = 0; i < DS18B20_ROM_BYTES; i++) {
         uart_write_hex(rom[i]);
-        if (i != 7) uart_tx_enqueue_byte(' ');
+        if (i != DS18B20_ROM_BYTES - 1) uart_tx_enqueue_byte(' ');
     }
-    uart_write_str(is_ds18b20 ? "\r\n" : " (not DS18B20, skipped)\r\n");
+    uart_write_str("\r\n");
     return 0;
 }
 
 /**
- * @brief Enumerate all DS18B20 devices on the 1-Wire bus (blocking)
- * @param[in] sink Callback invoked once per found DS18B20 device with its
- *                 64-bit ROM address (LSB first). May be NULL to only count
- *                 devices. Return non-zero from the callback to stop the
- *                 search early.
- * @param[in] max_devices Maximum number of devices to report (0 aborts)
- * @return Number of DS18B20 devices found on the bus
- * @note BLOCKING: busy-waits on the timer update flag (~15 ms per device).
- *       Intended for one-time use at startup before the main loop starts
- *       polling. Implements the standard Maxim 1-Wire Search ROM (0xF0)
- *       algorithm with the last-discrepancy method and CRC-8 validation.
- *       Only devices whose ROM family code is DS18B20_FAMILY_CODE (0x28)
- *       are reported; other 1-Wire devices are silently skipped.
+ * @brief Report the bus scan result once the non-blocking search finished
+ * @note Non-blocking: only enqueues into the UART TX ring buffer.
  */
-static uint8_t search_all_devices(uint8_t (*sink)(const uint8_t* rom), uint8_t max_devices) {
-    uint8_t rom[DS18B20_ROM_BYTES] = {0};
-    uint8_t found = 0;
-    uint8_t last_device = 0;
-    uint16_t last_discrepancy = 0;
-
-    if (max_devices == 0) {
-        return 0;
-    }
-
-    while (!last_device && found < max_devices) {
-        // A reset + presence pulse is required before EVERY Search ROM pass:
-        // after a completed search transaction the found device is left
-        // selected and the other devices go into a "not participating"
-        // state, so only a reset brings them all back to search mode.
-        if (!ds18b20_reset()) {
-            break;
-        }
-
-        ds18b20_write_byte(DS18B20_SEARCH_ROM);
-
-        uint16_t id_bit_number = 1;
-        uint16_t last_zero = 0;
-        for (uint8_t byte_idx = 0; byte_idx < DS18B20_ROM_BYTES; byte_idx++) {
-            uint8_t mask = 1;
-            for (uint8_t bit_idx = 0; bit_idx < DS18B20_BITS_PER_BYTE; bit_idx++) {
-                uint8_t id_bit = ds18b20_read_bit();
-                uint8_t cmp_bit = ds18b20_read_bit();
-                uint8_t direction;
-                if (id_bit && cmp_bit) {
-                    // No device follows this path - search tree exhausted
-                    ds18b20_restore();
-                    return found;
-                }
-                if (id_bit != cmp_bit) {
-                    // Single device on this path - its bit fixes the direction
-                    direction = id_bit;
-                } else if (id_bit_number < last_discrepancy) {
-                    // Follow the previously taken path
-                    direction = (rom[byte_idx] & mask) ? 1u : 0u;
-                    if (direction == 0) {
-                        // Remember the last 0-branch taken at a discrepancy
-                        last_zero = id_bit_number;
-                    }
-                } else {
-                    // At the discrepancy point take the '1' branch first
-                    direction = (id_bit_number == last_discrepancy) ? 1u : 0u;
-                    if (direction == 0) {
-                        // Remember the last 0-branch taken at a discrepancy
-                        last_zero = id_bit_number;
-                    }
-                }
-                if (direction) {
-                    rom[byte_idx] |= mask;
-                } else {
-                    rom[byte_idx] &= (uint8_t)~mask;
-                }
-                ds18b20_write_bit(direction);
-                id_bit_number++;
-                mask <<= 1;
-            }
-        }
-        last_discrepancy = last_zero;
-
-        // Validate the assembled ROM address
-        if (ds18b20_crc8(rom, DS18B20_ROM_BYTES) != 0) {
-            break;
-        }
-
-        // Only report DS18B20 devices; other 1-Wire families share the bus
-        // but are not temperature sensors and must not be measured as one.
-        if (rom[0] != DS18B20_FAMILY_CODE) {
-            if (last_discrepancy == 0) {
-                last_device = 1; // This was the last device on the bus
-            }
-            continue;
-        }
-
-        found++;
-        if (sink && sink(rom)) {
-            break; // Callback requested an early stop
-        }
-        if (last_discrepancy == 0) {
-            last_device = 1; // This was the last device on the bus
-        }
-    }
-
-    // Restore the non-blocking state machine so the first poll() begins
-    ds18b20_restore();
-    return found;
-}
-
-/**
- * @brief Run the blocking bus scan once at startup and report the result
- * @note The output is enqueued into the UART ring buffer; call uart_tx_flush()
- *       afterwards so the full banner is transmitted before the main loop.
- */
-static void search_devices_and_report(void) {
-    uart_write_str("Searching 1-Wire bus...\r\n");
-    uint8_t count = search_all_devices(device_found_sink, DS18B20_SEARCH_MAX_DEVICES);
-    if (count == 0) {
+static void report_search_result(void) {
+    if (found_count == 0) {
         uart_write_str("No devices on the 1-Wire bus.\r\n");
     } else {
         uart_write_str("Found ");
-        uart_write_int(count);
+        uart_write_int(found_count);
         uart_write_str(" device(s).\r\n");
         select_index = 0;
         ds18b20_select(found_roms[select_index]);
-        if (count == 1) {
+        if (found_count == 1) {
             uart_write_str("Measuring the single device.\r\n");
         } else {
             uart_write_str("Measuring devices in turn.\r\n");
@@ -179,9 +73,9 @@ static void search_devices_and_report(void) {
  * @return Number of characters enqueued
  */
 static int print_device_prefix(void) {
-    for (uint8_t i = 0; i < 8; i++) {
+    for (uint8_t i = 0; i < DS18B20_ROM_BYTES; i++) {
         uart_write_hex(found_roms[select_index][i]);
-        if (i != 7) uart_tx_enqueue_byte(' ');
+        if (i != DS18B20_ROM_BYTES - 1) uart_tx_enqueue_byte(' ');
     }
     uart_write_str(": ");
     return 25; // 8 bytes * 2 hex chars + 7 spaces + ": "
@@ -231,20 +125,31 @@ void ds18b20_complete(int16_t temp) {
 
 /**
  * @brief Main application entry point
- * @note Implements non-blocking architecture with periodic polling
+ * @note Implements a fully non-blocking architecture with periodic polling:
+ *       first the device search advances step by step, then the measurement
+ *       state machine takes over and measures every found sensor in turn.
  */
 int main(void) {
 
     app_init(); // System clock, UART and LED GPIO - single setup call
 
     uart_write_str("DS18B20 demo starting...\r\n"); // Enqueue startup message
+    uart_write_str("Searching 1-Wire bus...\r\n"); // Enqueue search banner
     ds18b20_init(); // Initialize DS18B20 driver (non-blocking)
-    search_devices_and_report(); // Blocking one-time bus scan (all sensors)
-    uart_tx_flush(); // Block until the startup banner is fully transmitted
+    ds18b20_search_start(device_found_sink, DS18B20_SEARCH_MAX_DEVICES); // Start scan
 
     for (;;) { // Main event loop (non-blocking, cooperative multitasking)
 
-        ds18b20_poll(); // Poll DS18B20 state machine - advances 1-Wire communication state
+        if (search_running) {
+            // Advance the non-blocking device search by one hardware operation
+            if (ds18b20_search_poll()) {
+                search_running = 0;
+                found_count = ds18b20_search_count();
+                report_search_result();
+            }
+        } else {
+            ds18b20_poll(); // Poll DS18B20 state machine - measures devices in turn
+        }
         uart_poll_tx(); // Poll UART transmission - feeds hardware from buffer
         // Other non-blocking tasks can be added here
     }

--- a/src/demo2.c
+++ b/src/demo2.c
@@ -70,12 +70,15 @@ __STATIC_FORCEINLINE void uart_tx_enqueue_byte(uint8_t b) {
 /**
  * @brief Enqueue an entire null-terminated string (lossless)
  * @param[in] s Null-terminated string to enqueue
+ * @return Number of characters enqueued
  */
-__STATIC_FORCEINLINE void uart_write_str(const char* s) {
+__STATIC_FORCEINLINE int uart_write_str(const char* s) {
+    const char* start = s;
     while (*s) {
         uart_tx_enqueue_byte((uint8_t)*s);
         s++;
     }
+    return (int)(s - start);
 }
 
 /**
@@ -173,8 +176,9 @@ void ds18b20_busy(unsigned action) {
 /**
  * @brief Convert integer to string and enqueue for UART transmission
  * @param[in] value Integer value to convert and transmit
+ * @return Number of characters enqueued
  */
-__STATIC_FORCEINLINE void uart_write_int(int value) {
+__STATIC_FORCEINLINE int uart_write_int(int value) {
     char buf[7]; // enough for -32768 and '\0'
     char* p = buf + sizeof(buf) - 1;
     *p = '\0';
@@ -199,17 +203,19 @@ __STATIC_FORCEINLINE void uart_write_int(int value) {
 
         if (is_negative) *(--p) = '-'; // Add negative sign if needed
     }
-    uart_write_str(p);
+    return uart_write_str(p);
 }
 
 /**
- * @brief Enqueue one byte as two uppercase hexadecimal digits (best-effort)
+ * @brief Enqueue one byte as two uppercase hexadecimal digits
  * @param[in] b Byte to convert and transmit
+ * @return Number of characters enqueued (always 2)
  */
-__STATIC_FORCEINLINE void uart_write_hex(uint8_t b) {
+__STATIC_FORCEINLINE int uart_write_hex(uint8_t b) {
     static const char hex[] = "0123456789ABCDEF";
     uart_tx_enqueue_byte((uint8_t)hex[(b >> 4) & 0x0F]);
     uart_tx_enqueue_byte((uint8_t)hex[b & 0x0F]);
+    return 2;
 }
 
 /**
@@ -260,13 +266,15 @@ __STATIC_FORCEINLINE void search_devices_and_report(void) {
 
 /**
  * @brief Print the ROM address of the currently selected device followed by ": "
+ * @return Number of characters enqueued
  */
-__STATIC_FORCEINLINE void print_device_prefix(void) {
+__STATIC_FORCEINLINE int print_device_prefix(void) {
     for (uint8_t i = 0; i < 8; i++) {
         uart_write_hex(found_roms[select_index][i]);
         if (i != 7) uart_tx_enqueue_byte(' ');
     }
     uart_write_str(": ");
+    return 25; // 8 bytes * 2 hex chars + 7 spaces + ": "
 }
 
 /**
@@ -274,31 +282,40 @@ __STATIC_FORCEINLINE void print_device_prefix(void) {
  * @param[in] temp Temperature value in tenths of degrees Celsius, or error code
  */
 void ds18b20_complete(int16_t temp) {
-    print_device_prefix(); // ROM of the device that was just measured
+    int line_len = print_device_prefix(); // ROM of the device that was just measured
     if (temp == DS18B20_TEMP_ERROR_NO_SENSOR) { // No sensor detected error - enqueue error message
-        uart_write_str("no sensor detected.\r\n");
+        line_len += uart_write_str("no sensor detected.");
     } else if (temp == DS18B20_TEMP_ERROR_CRC_FAIL) { // CRC check failed error - enqueue error message
-        uart_write_str("CRC check failed.\r\n");
+        line_len += uart_write_str("CRC check failed.");
     } else if (temp == DS18B20_TEMP_ERROR_GENERIC) { // Generic error - enqueue error message
-        uart_write_str("generic failure.\r\n");
+        line_len += uart_write_str("generic failure.");
     } else { // Valid temperature reading - format and display
         int whole = temp / 10; // Get whole degrees (temp is in tenths)
         int frac = temp % 10; // Get fractional part (tenths)
         if (frac < 0) frac = -frac; // Ensure fractional part is positive
         if (whole == 0 && temp < 0) {
-            uart_write_str("-0"); // Handle -0.5°C case
+            line_len += uart_write_str("-0"); // Handle -0.5°C case
         } else {
-            uart_write_int(whole); // Display whole part
+            line_len += uart_write_int(whole); // Display whole part
         }
-        uart_write_str("."); // Decimal point
-        uart_write_int(frac); // Display fractional part
-        uart_write_str(" C\r\n"); // Units and newline
+        line_len += uart_write_str("."); // Decimal point
+        line_len += uart_write_int(frac); // Display fractional part
+        line_len += uart_write_str(" C"); // Units
     }
+    uart_write_str("\r\n"); // And newline (not counted in line length)
 
     // Round-robin: switch to the next device for the next measurement cycle
     if (found_count > 1) {
         select_index = (uint8_t)((select_index + 1u) % found_count);
         ds18b20_select(found_roms[select_index]);
+        if (select_index == 0) {
+            // Every sensor has been measured - close the cycle with a
+            // separator as wide as the measurement line
+            for (int i = 0; i < line_len; i++) {
+                uart_tx_enqueue_byte('-');
+            }
+            uart_write_str("\r\n");
+        }
     }
 }
 

--- a/src/demo2.c
+++ b/src/demo2.c
@@ -1,10 +1,12 @@
 /**
  * @file demo2.c
  * @brief Multi-sensor example: startup bus scan + round-robin polling
- * 
- * Demonstrates ds18b20_search_devices() to enumerate every DS18B20 on the
- * bus, then ds18b20_select() to measure each sensor in turn. The shared
- * platform layer (app.h/app.c) hides the UART and clock setup.
+ *
+ * Demonstrates a Maxim 1-Wire Search ROM bus scan using the driver's
+ * low-level blocking primitives (ds18b20_reset, ds18b20_write_bit,
+ * ds18b20_read_bit, ds18b20_crc8), then ds18b20_select() to measure each
+ * sensor in turn. The shared platform layer (app.h/app.c) hides the UART and
+ * clock setup.
  */
 
 #include "app.h"
@@ -42,13 +44,120 @@ static uint8_t device_found_sink(const uint8_t* rom) {
 }
 
 /**
+ * @brief Enumerate all DS18B20 devices on the 1-Wire bus (blocking)
+ * @param[in] sink Callback invoked once per found DS18B20 device with its
+ *                 64-bit ROM address (LSB first). May be NULL to only count
+ *                 devices. Return non-zero from the callback to stop the
+ *                 search early.
+ * @param[in] max_devices Maximum number of devices to report (0 aborts)
+ * @return Number of DS18B20 devices found on the bus
+ * @note BLOCKING: busy-waits on the timer update flag (~15 ms per device).
+ *       Intended for one-time use at startup before the main loop starts
+ *       polling. Implements the standard Maxim 1-Wire Search ROM (0xF0)
+ *       algorithm with the last-discrepancy method and CRC-8 validation.
+ *       Only devices whose ROM family code is DS18B20_FAMILY_CODE (0x28)
+ *       are reported; other 1-Wire devices are silently skipped.
+ */
+static uint8_t search_all_devices(uint8_t (*sink)(const uint8_t* rom), uint8_t max_devices) {
+    uint8_t rom[DS18B20_ROM_BYTES] = {0};
+    uint8_t found = 0;
+    uint8_t last_device = 0;
+    uint16_t last_discrepancy = 0;
+
+    if (max_devices == 0) {
+        return 0;
+    }
+
+    while (!last_device && found < max_devices) {
+        // A reset + presence pulse is required before EVERY Search ROM pass:
+        // after a completed search transaction the found device is left
+        // selected and the other devices go into a "not participating"
+        // state, so only a reset brings them all back to search mode.
+        if (!ds18b20_reset()) {
+            break;
+        }
+
+        ds18b20_write_byte(DS18B20_SEARCH_ROM);
+
+        uint16_t id_bit_number = 1;
+        uint16_t last_zero = 0;
+        for (uint8_t byte_idx = 0; byte_idx < DS18B20_ROM_BYTES; byte_idx++) {
+            uint8_t mask = 1;
+            for (uint8_t bit_idx = 0; bit_idx < DS18B20_BITS_PER_BYTE; bit_idx++) {
+                uint8_t id_bit = ds18b20_read_bit();
+                uint8_t cmp_bit = ds18b20_read_bit();
+                uint8_t direction;
+                if (id_bit && cmp_bit) {
+                    // No device follows this path - search tree exhausted
+                    ds18b20_restore();
+                    return found;
+                }
+                if (id_bit != cmp_bit) {
+                    // Single device on this path - its bit fixes the direction
+                    direction = id_bit;
+                } else if (id_bit_number < last_discrepancy) {
+                    // Follow the previously taken path
+                    direction = (rom[byte_idx] & mask) ? 1u : 0u;
+                    if (direction == 0) {
+                        // Remember the last 0-branch taken at a discrepancy
+                        last_zero = id_bit_number;
+                    }
+                } else {
+                    // At the discrepancy point take the '1' branch first
+                    direction = (id_bit_number == last_discrepancy) ? 1u : 0u;
+                    if (direction == 0) {
+                        // Remember the last 0-branch taken at a discrepancy
+                        last_zero = id_bit_number;
+                    }
+                }
+                if (direction) {
+                    rom[byte_idx] |= mask;
+                } else {
+                    rom[byte_idx] &= (uint8_t)~mask;
+                }
+                ds18b20_write_bit(direction);
+                id_bit_number++;
+                mask <<= 1;
+            }
+        }
+        last_discrepancy = last_zero;
+
+        // Validate the assembled ROM address
+        if (ds18b20_crc8(rom, DS18B20_ROM_BYTES) != 0) {
+            break;
+        }
+
+        // Only report DS18B20 devices; other 1-Wire families share the bus
+        // but are not temperature sensors and must not be measured as one.
+        if (rom[0] != DS18B20_FAMILY_CODE) {
+            if (last_discrepancy == 0) {
+                last_device = 1; // This was the last device on the bus
+            }
+            continue;
+        }
+
+        found++;
+        if (sink && sink(rom)) {
+            break; // Callback requested an early stop
+        }
+        if (last_discrepancy == 0) {
+            last_device = 1; // This was the last device on the bus
+        }
+    }
+
+    // Restore the non-blocking state machine so the first poll() begins
+    ds18b20_restore();
+    return found;
+}
+
+/**
  * @brief Run the blocking bus scan once at startup and report the result
  * @note The output is enqueued into the UART ring buffer; call uart_tx_flush()
  *       afterwards so the full banner is transmitted before the main loop.
  */
 static void search_devices_and_report(void) {
     uart_write_str("Searching 1-Wire bus...\r\n");
-    uint8_t count = ds18b20_search_devices(device_found_sink, DS18B20_SEARCH_MAX_DEVICES);
+    uint8_t count = search_all_devices(device_found_sink, DS18B20_SEARCH_MAX_DEVICES);
     if (count == 0) {
         uart_write_str("No devices on the 1-Wire bus.\r\n");
     } else {

--- a/src/demo2.c
+++ b/src/demo2.c
@@ -202,7 +202,8 @@ __STATIC_FORCEINLINE void uart_write_hex(uint8_t b) {
  * @return 0 to continue the search
  */
 static uint8_t device_found_sink(const uint8_t* rom) {
-    if (found_count < DS18B20_SEARCH_MAX_DEVICES) {
+    const uint8_t is_ds18b20 = (rom[0] == DS18B20_FAMILY_CODE);
+    if (is_ds18b20 && found_count < DS18B20_SEARCH_MAX_DEVICES) {
         for (uint8_t i = 0; i < 8; i++) {
             found_roms[found_count][i] = rom[i];
         }
@@ -213,7 +214,7 @@ static uint8_t device_found_sink(const uint8_t* rom) {
         uart_write_hex(rom[i]);
         if (i != 7) (void)uart_tx_enqueue_byte(' ');
     }
-    uart_write_str("\r\n");
+    uart_write_str(is_ds18b20 ? "\r\n" : " (not DS18B20, skipped)\r\n");
     return 0;
 }
 

--- a/src/demo2.c
+++ b/src/demo2.c
@@ -31,45 +31,8 @@ static uint8_t uart_tx_tail = 0; // read index - points to oldest data
 static uint8_t uart_tx_buf[UART_TX_BUF_SIZE]; // circular buffer for UART transmission
 
 /**
- * @brief Non-blocking function to enqueue a single byte into the UART transmit buffer
- * @param[in] b Byte to enqueue
- * @return 1 on success, 0 if buffer full
- * @note Returns immediately without blocking
- */
-__STATIC_FORCEINLINE int uart_tx_enqueue_byte(uint8_t b) {
-    uint8_t head = uart_tx_head;
-    // Calculate next head position with wrap-around using power-of-two mask
-    uint8_t next = (uint8_t)((head + 1u) & UART_TX_IDX_MASK);
-    if (next == uart_tx_tail) { // Check if buffer is full
-        return 0; // Buffer full - non-blocking return
-    }
-
-    uart_tx_buf[head] = b; // Store byte at current head position
-    uart_tx_head = next; // Atomically update head pointer
-    return 1; // Success
-}
-
-/**
- * @brief Non-blocking function to enqueue entire null-terminated string into UART transmit buffer
- * @param[in] s Null-terminated string to enqueue
- * @return Number of characters successfully enqueued
- */
-__STATIC_FORCEINLINE int uart_write_str(const char* s) {
-    const char* start = s;
-    // Process each character until null terminator
-    while (*s) {
-        // Try to enqueue current character, break on buffer full (non-blocking)
-        if (!uart_tx_enqueue_byte((uint8_t)*s)) break;
-        s++;
-    }
-    // Return count of successfully enqueued characters
-    return (int)(s - start);
-}
-
-/**
- * @brief Non-blocking function to advance UART transmission by at most one byte
- * @note Must be called periodically to feed UART hardware from buffer
- * @note Returns immediately without blocking
+ * @brief Advance UART transmission by at most one byte (non-blocking)
+ * @note Must be called periodically to feed UART hardware from the buffer
  */
 __STATIC_FORCEINLINE void uart_poll_tx(void) {
     // Check if UART is ready to transmit (TXE flag set) and buffer not empty
@@ -80,6 +43,54 @@ __STATIC_FORCEINLINE void uart_poll_tx(void) {
         uart_tx_tail = (uint8_t)((uart_tx_tail + 1u) & UART_TX_IDX_MASK);
         // Write byte to UART data register for transmission
         USART1->DR = b;
+    }
+}
+
+/**
+ * @brief Enqueue a single byte into the UART transmit buffer (lossless)
+ * @param[in] b Byte to enqueue
+ * @note Blocks only while the buffer is full, polling uart_poll_tx() to make
+ *       room - a byte is never dropped. With a 256-byte buffer the worst-case
+ *       stall at 115200 baud is ~23 ms.
+ */
+__STATIC_FORCEINLINE void uart_tx_enqueue_byte(uint8_t b) {
+    for (;;) {
+        uint8_t head = uart_tx_head;
+        // Calculate next head position with wrap-around using power-of-two mask
+        uint8_t next = (uint8_t)((head + 1u) & UART_TX_IDX_MASK);
+        if (next != uart_tx_tail) { // Room is available
+            uart_tx_buf[head] = b; // Store byte at current head position
+            uart_tx_head = next; // Update head pointer
+            return;
+        }
+        uart_poll_tx(); // Make room by feeding one byte to the UART
+    }
+}
+
+/**
+ * @brief Enqueue an entire null-terminated string (lossless)
+ * @param[in] s Null-terminated string to enqueue
+ */
+__STATIC_FORCEINLINE void uart_write_str(const char* s) {
+    while (*s) {
+        uart_tx_enqueue_byte((uint8_t)*s);
+        s++;
+    }
+}
+
+/**
+ * @brief Blocking drain of the UART TX ring buffer
+ * @note Waits until every enqueued byte has been shifted out (TC set).
+ *       Call once at startup after the bus-scan report so the banner is
+ *       never truncated, regardless of buffer size vs. message length.
+ *       At 115200 baud a 256-byte buffer drains in ~23 ms.
+ */
+__STATIC_FORCEINLINE void uart_tx_flush(void) {
+    while (uart_tx_tail != uart_tx_head) {
+        uart_poll_tx();
+    }
+    while (!(USART1->SR & USART_SR_TC)) {
+        ;
     }
 }
 
@@ -183,7 +194,7 @@ __STATIC_FORCEINLINE void uart_write_int(int value) {
 
         if (is_negative) *(--p) = '-'; // Add negative sign if needed
     }
-    (void)uart_write_str(p); // best-effort enqueue to UART buffer
+    uart_write_str(p);
 }
 
 /**
@@ -192,8 +203,8 @@ __STATIC_FORCEINLINE void uart_write_int(int value) {
  */
 __STATIC_FORCEINLINE void uart_write_hex(uint8_t b) {
     static const char hex[] = "0123456789ABCDEF";
-    (void)uart_tx_enqueue_byte((uint8_t)hex[(b >> 4) & 0x0F]);
-    (void)uart_tx_enqueue_byte((uint8_t)hex[b & 0x0F]);
+    uart_tx_enqueue_byte((uint8_t)hex[(b >> 4) & 0x0F]);
+    uart_tx_enqueue_byte((uint8_t)hex[b & 0x0F]);
 }
 
 /**
@@ -212,7 +223,7 @@ static uint8_t device_found_sink(const uint8_t* rom) {
     uart_write_str("  ROM: ");
     for (uint8_t i = 0; i < 8; i++) {
         uart_write_hex(rom[i]);
-        if (i != 7) (void)uart_tx_enqueue_byte(' ');
+        if (i != 7) uart_tx_enqueue_byte(' ');
     }
     uart_write_str(is_ds18b20 ? "\r\n" : " (not DS18B20, skipped)\r\n");
     return 0;
@@ -220,9 +231,8 @@ static uint8_t device_found_sink(const uint8_t* rom) {
 
 /**
  * @brief Run the blocking bus scan once at startup and report the result
- * @note The output is enqueued into the UART ring buffer; it is flushed by
- *       uart_poll_tx() once the main loop starts. Up to ~5 devices fit in
- *       the buffer before the output is truncated (best-effort).
+ * @note The output is enqueued into the UART ring buffer; call uart_tx_flush()
+ *       afterwards so the full banner is transmitted before the main loop.
  */
 __STATIC_FORCEINLINE void search_devices_and_report(void) {
     uart_write_str("Searching 1-Wire bus...\r\n");
@@ -244,15 +254,14 @@ __STATIC_FORCEINLINE void search_devices_and_report(void) {
 }
 
 /**
- * @brief Print the ROM address of the currently selected device (best-effort)
+ * @brief Print the ROM address of the currently selected device followed by ": "
  */
-__STATIC_FORCEINLINE void print_selected_rom(void) {
-    uart_write_str(" -> ");
+__STATIC_FORCEINLINE void print_device_prefix(void) {
     for (uint8_t i = 0; i < 8; i++) {
         uart_write_hex(found_roms[select_index][i]);
-        if (i != 7) (void)uart_tx_enqueue_byte(' ');
+        if (i != 7) uart_tx_enqueue_byte(' ');
     }
-    uart_write_str("\r\n");
+    uart_write_str(": ");
 }
 
 /**
@@ -260,17 +269,17 @@ __STATIC_FORCEINLINE void print_selected_rom(void) {
  * @param[in] temp Temperature value in tenths of degrees Celsius, or error code
  */
 void ds18b20_complete(int16_t temp) {
+    print_device_prefix(); // ROM of the device that was just measured
     if (temp == DS18B20_TEMP_ERROR_NO_SENSOR) { // No sensor detected error - enqueue error message
-        uart_write_str("DS18B20 error: no sensor detected.\r\n");
+        uart_write_str("no sensor detected.\r\n");
     } else if (temp == DS18B20_TEMP_ERROR_CRC_FAIL) { // CRC check failed error - enqueue error message
-        uart_write_str("DS18B20 error: CRC check failed.\r\n");
+        uart_write_str("CRC check failed.\r\n");
     } else if (temp == DS18B20_TEMP_ERROR_GENERIC) { // Generic error - enqueue error message
-        uart_write_str("DS18B20 error: generic failure.\r\n");
+        uart_write_str("generic failure.\r\n");
     } else { // Valid temperature reading - format and display
         int whole = temp / 10; // Get whole degrees (temp is in tenths)
         int frac = temp % 10; // Get fractional part (tenths)
         if (frac < 0) frac = -frac; // Ensure fractional part is positive
-        uart_write_str("Temperature: ");
         if (whole == 0 && temp < 0) {
             uart_write_str("-0"); // Handle -0.5°C case
         } else {
@@ -278,15 +287,13 @@ void ds18b20_complete(int16_t temp) {
         }
         uart_write_str("."); // Decimal point
         uart_write_int(frac); // Display fractional part
-        uart_write_str(" C"); // Units
-        uart_write_str("\r\n"); // And newline
+        uart_write_str(" C\r\n"); // Units and newline
     }
 
     // Round-robin: switch to the next device for the next measurement cycle
     if (found_count > 1) {
         select_index = (uint8_t)((select_index + 1u) % found_count);
         ds18b20_select(found_roms[select_index]);
-        print_selected_rom();
     }
 }
 
@@ -302,6 +309,7 @@ int main(void) {
     uart_write_str("DS18B20 demo starting...\r\n"); // Enqueue startup message to UART buffer
     ds18b20_init(); // Initialize DS18B20 driver (non-blocking)
     search_devices_and_report(); // Blocking one-time bus scan (all sensors)
+    uart_tx_flush(); // Block until the startup banner is fully transmitted
 
     for (;;) { // Main event loop (non-blocking, cooperative multitasking)
 

--- a/src/demo2.c
+++ b/src/demo2.c
@@ -1,10 +1,14 @@
-#include "ds18b20.h"
-#include "stm32f1xx.h"
+/**
+ * @file demo2.c
+ * @brief Multi-sensor example: startup bus scan + round-robin polling
+ * 
+ * Demonstrates ds18b20_search_devices() to enumerate every DS18B20 on the
+ * bus, then ds18b20_select() to measure each sensor in turn. The shared
+ * platform layer (app.h/app.c) hides the UART and clock setup.
+ */
 
-// ======== Config: printing buffer size (power of two) ========
-#ifndef UART_TX_BUF_SIZE
-#define UART_TX_BUF_SIZE 256u // set to 128 or 256 as desired
-#endif
+#include "app.h"
+
 // ======== Config: maximum devices reported by the startup bus scan ========
 #ifndef DS18B20_SEARCH_MAX_DEVICES
 #define DS18B20_SEARCH_MAX_DEVICES 8u
@@ -14,209 +18,6 @@
 static uint8_t found_roms[DS18B20_SEARCH_MAX_DEVICES][8]; // ROMs found at startup
 static uint8_t found_count = 0; // how many devices were found
 static uint8_t select_index = 0; // index of the currently selected device
-
-// Validate that buffer size is a power of two for efficient masking operations
-#if (UART_TX_BUF_SIZE & (UART_TX_BUF_SIZE - 1u)) != 0
-#error "UART_TX_BUF_SIZE must be a power of two (e.g., 32, 64, 128, 256)."
-#endif
-
-// Create mask for buffer index wrapping (power of two optimization)
-#define UART_TX_IDX_MASK (UART_TX_BUF_SIZE - 1u)
-// Calculate baud rate register value with rounding for accuracy
-#define USART_BRR_CALC(PCLK, BAUD) (((PCLK) + ((BAUD) / 2)) / (BAUD))
-
-// ======== USART1 TX ring buffer ========
-static uint8_t uart_tx_head = 0; // write index - points to next free slot
-static uint8_t uart_tx_tail = 0; // read index - points to oldest data
-static uint8_t uart_tx_buf[UART_TX_BUF_SIZE]; // circular buffer for UART transmission
-
-/**
- * @brief Advance UART transmission by at most one byte (non-blocking)
- * @note Must be called periodically to feed UART hardware from the buffer
- */
-__STATIC_FORCEINLINE void uart_poll_tx(void) {
-    // Check if UART is ready to transmit (TXE flag set) and buffer not empty
-    if ((USART1->SR & USART_SR_TXE) && (uart_tx_tail != uart_tx_head)) {
-        // Get byte from buffer at tail position
-        uint8_t b = uart_tx_buf[uart_tx_tail];
-        // Advance tail pointer with wrap-around
-        uart_tx_tail = (uint8_t)((uart_tx_tail + 1u) & UART_TX_IDX_MASK);
-        // Write byte to UART data register for transmission
-        USART1->DR = b;
-    }
-}
-
-/**
- * @brief Enqueue a single byte into the UART transmit buffer (lossless)
- * @param[in] b Byte to enqueue
- * @note Blocks only while the buffer is full, polling uart_poll_tx() to make
- *       room - a byte is never dropped. With a 256-byte buffer the worst-case
- *       stall at 115200 baud is ~23 ms.
- */
-__STATIC_FORCEINLINE void uart_tx_enqueue_byte(uint8_t b) {
-    for (;;) {
-        uint8_t head = uart_tx_head;
-        // Calculate next head position with wrap-around using power-of-two mask
-        uint8_t next = (uint8_t)((head + 1u) & UART_TX_IDX_MASK);
-        if (next != uart_tx_tail) { // Room is available
-            uart_tx_buf[head] = b; // Store byte at current head position
-            uart_tx_head = next; // Update head pointer
-            return;
-        }
-        uart_poll_tx(); // Make room by feeding one byte to the UART
-    }
-}
-
-/**
- * @brief Enqueue an entire null-terminated string (lossless)
- * @param[in] s Null-terminated string to enqueue
- * @return Number of characters enqueued
- */
-__STATIC_FORCEINLINE int uart_write_str(const char* s) {
-    const char* start = s;
-    while (*s) {
-        uart_tx_enqueue_byte((uint8_t)*s);
-        s++;
-    }
-    return (int)(s - start);
-}
-
-/**
- * @brief Blocking drain of the UART TX ring buffer
- * @note Waits until every enqueued byte has been shifted out (TC set).
- *       Call once at startup after the bus-scan report so the banner is
- *       never truncated, regardless of buffer size vs. message length.
- *       At 115200 baud a 256-byte buffer drains in ~23 ms.
- */
-__STATIC_FORCEINLINE void uart_tx_flush(void) {
-    while (uart_tx_tail != uart_tx_head) {
-        uart_poll_tx();
-    }
-    while (!(USART1->SR & USART_SR_TC)) {
-        ;
-    }
-}
-
-/**
- * @brief Configure system clock (72MHz via HSE+PLL, or skip for HSI 8MHz)
- */
-__STATIC_FORCEINLINE void configure_system_clock(void) {
-#ifndef HSI_8MHZ
-    // Enable HSI and HSE oscillators
-    RCC->CR = RCC_CR_HSION | RCC_CR_HSEON;
-    // Wait for HSE to stabilize - HSERDY is the hardware stabilization
-    // indicator, so no fixed delay is required
-    while (!(RCC->CR & RCC_CR_HSERDY))
-        ;
-    // Configure PLL: HSE source, multiply by 9, APB1 prescaler /2
-    RCC->CFGR = RCC_CFGR_PLLSRC | RCC_CFGR_PLLMULL9 | RCC_CFGR_PPRE1_DIV2;
-    // Enable PLL only after HSE is confirmed stable, so the PLL locks on a
-    // valid clock (per RM0008: HSE must be ready before enabling the PLL)
-    RCC->CR |= RCC_CR_PLLON;
-    // Wait for the PLL to lock
-    while (!(RCC->CR & RCC_CR_PLLRDY))
-        ;
-    // Configure flash latency for 72MHz operation
-    FLASH->ACR = FLASH_ACR_PRFTBE | FLASH_ACR_LATENCY_2;
-    // Switch system clock to PLL
-    RCC->CFGR = RCC_CFGR_PLLSRC | RCC_CFGR_PLLMULL9 | RCC_CFGR_PPRE1_DIV2 | RCC_CFGR_SW_PLL;
-    // Wait for system clock switch to PLL
-    while ((RCC->CFGR & RCC_CFGR_SWS_PLL) != RCC_CFGR_SWS_PLL)
-        ;
-    // Disable HSI oscillator
-    RCC->CR &= ~RCC_CR_HSION;
-#endif
-    // HSI_8MHZ: MCU already runs on HSI 8MHz after reset — nothing to configure
-}
-
-/**
- * @brief Initialize microcontroller peripherals for UART communication and LED control
- */
-__STATIC_FORCEINLINE void hardware_init(void) {
-
-    // Enable clock for GPIOA, USART1, and GPIOC peripherals
-    RCC->APB2ENR |= (RCC_APB2ENR_IOPAEN | RCC_APB2ENR_USART1EN | RCC_APB2ENR_IOPCEN);
-
-    // Configure PA9 as alternate function push-pull output, 2MHz speed
-    // Clear existing configuration bits
-    GPIOA->CRH &= ~(GPIO_CRH_MODE9 | GPIO_CRH_CNF9);
-    // Set alternate function push-pull output mode, 2MHz speed
-    GPIOA->CRH |= (GPIO_CRH_MODE9_1 | GPIO_CRH_CNF9_1);
-
-    // Configure PC13 as general purpose output, 2MHz speed for LED control
-    GPIOC->CRH &= ~(GPIO_CRH_MODE13 | GPIO_CRH_CNF13);
-    GPIOC->CRH |= GPIO_CRH_MODE13_1;
-
-    // Configure USART1: 115200 baud, 8 data bits, no parity, 1 stop bit, TX only
-#ifdef HSI_8MHZ
-    USART1->BRR = USART_BRR_CALC(8000000, 115200); // PCLK2=8MHz
-#else
-    USART1->BRR = USART_BRR_CALC(72000000, 115200); // PCLK2=72MHz
-#endif
-    USART1->CR1 = USART_CR1_TE | USART_CR1_UE; // Enable USART1; TX enable only
-}
-
-/**
- * @brief Busy indicator - toggles LED during measurement
- * @param[in] action 0 = idle, non-zero = busy
- * @note Non-blocking LED control using atomic BSRR register operations
- */
-void ds18b20_busy(unsigned action) {
-    if (action) {
-        // Turn LED on (PC13 low due to pull-up LED configuration)
-        // BSRR BR register: atomic bit reset operation
-        GPIOC->BSRR = GPIO_BSRR_BR13;
-    } else {
-        // Turn LED off (PC13 high)
-        // BSRR BS register: atomic bit set operation
-        GPIOC->BSRR = GPIO_BSRR_BS13;
-    }
-}
-
-/**
- * @brief Convert integer to string and enqueue for UART transmission
- * @param[in] value Integer value to convert and transmit
- * @return Number of characters enqueued
- */
-__STATIC_FORCEINLINE int uart_write_int(int value) {
-    char buf[7]; // enough for -32768 and '\0'
-    char* p = buf + sizeof(buf) - 1;
-    *p = '\0';
-
-    if (value == 0) { // Special case for zero
-        *(--p) = '0';
-    } else {
-        int is_negative = 0;
-        unsigned int uvalue;
-
-        if (value < 0) { // Handle negative numbers
-            is_negative = 1;
-            uvalue = (unsigned int)-(value + 1) + 1;
-        } else {
-            uvalue = value;
-        }
-
-        do { // Convert digits from least significant to most significant
-            *(--p) = '0' + (uvalue % 10);
-            uvalue /= 10;
-        } while (uvalue);
-
-        if (is_negative) *(--p) = '-'; // Add negative sign if needed
-    }
-    return uart_write_str(p);
-}
-
-/**
- * @brief Enqueue one byte as two uppercase hexadecimal digits
- * @param[in] b Byte to convert and transmit
- * @return Number of characters enqueued (always 2)
- */
-__STATIC_FORCEINLINE int uart_write_hex(uint8_t b) {
-    static const char hex[] = "0123456789ABCDEF";
-    uart_tx_enqueue_byte((uint8_t)hex[(b >> 4) & 0x0F]);
-    uart_tx_enqueue_byte((uint8_t)hex[b & 0x0F]);
-    return 2;
-}
 
 /**
  * @brief Device search callback - stores the ROM and prints it in hex
@@ -245,7 +46,7 @@ static uint8_t device_found_sink(const uint8_t* rom) {
  * @note The output is enqueued into the UART ring buffer; call uart_tx_flush()
  *       afterwards so the full banner is transmitted before the main loop.
  */
-__STATIC_FORCEINLINE void search_devices_and_report(void) {
+static void search_devices_and_report(void) {
     uart_write_str("Searching 1-Wire bus...\r\n");
     uint8_t count = ds18b20_search_devices(device_found_sink, DS18B20_SEARCH_MAX_DEVICES);
     if (count == 0) {
@@ -268,7 +69,7 @@ __STATIC_FORCEINLINE void search_devices_and_report(void) {
  * @brief Print the ROM address of the currently selected device followed by ": "
  * @return Number of characters enqueued
  */
-__STATIC_FORCEINLINE int print_device_prefix(void) {
+static int print_device_prefix(void) {
     for (uint8_t i = 0; i < 8; i++) {
         uart_write_hex(found_roms[select_index][i]);
         if (i != 7) uart_tx_enqueue_byte(' ');
@@ -325,10 +126,9 @@ void ds18b20_complete(int16_t temp) {
  */
 int main(void) {
 
-    configure_system_clock(); // Configure system clock for MCU
+    app_init(); // System clock, UART and LED GPIO - single setup call
 
-    hardware_init(); // Initialize hardware peripherals (non-blocking)
-    uart_write_str("DS18B20 demo starting...\r\n"); // Enqueue startup message to UART buffer
+    uart_write_str("DS18B20 demo starting...\r\n"); // Enqueue startup message
     ds18b20_init(); // Initialize DS18B20 driver (non-blocking)
     search_devices_and_report(); // Blocking one-time bus scan (all sensors)
     uart_tx_flush(); // Block until the startup banner is fully transmitted

--- a/src/demo2.c
+++ b/src/demo2.c
@@ -101,12 +101,17 @@ __STATIC_FORCEINLINE void configure_system_clock(void) {
 #ifndef HSI_8MHZ
     // Enable HSI and HSE oscillators
     RCC->CR = RCC_CR_HSION | RCC_CR_HSEON;
+    // Wait for HSE to stabilize - HSERDY is the hardware stabilization
+    // indicator, so no fixed delay is required
+    while (!(RCC->CR & RCC_CR_HSERDY))
+        ;
     // Configure PLL: HSE source, multiply by 9, APB1 prescaler /2
     RCC->CFGR = RCC_CFGR_PLLSRC | RCC_CFGR_PLLMULL9 | RCC_CFGR_PPRE1_DIV2;
-    // Enable PLL
-    RCC->CR = RCC_CR_HSION | RCC_CR_HSEON | RCC_CR_PLLON;
-    // Wait for PLL and HSE ready flags
-    while ((RCC_CR_PLLRDY | RCC_CR_HSERDY) != (RCC->CR & (RCC_CR_PLLRDY | RCC_CR_HSERDY)))
+    // Enable PLL only after HSE is confirmed stable, so the PLL locks on a
+    // valid clock (per RM0008: HSE must be ready before enabling the PLL)
+    RCC->CR |= RCC_CR_PLLON;
+    // Wait for the PLL to lock
+    while (!(RCC->CR & RCC_CR_PLLRDY))
         ;
     // Configure flash latency for 72MHz operation
     FLASH->ACR = FLASH_ACR_PRFTBE | FLASH_ACR_LATENCY_2;

--- a/src/demo2.c
+++ b/src/demo2.c
@@ -3,8 +3,17 @@
 
 // ======== Config: printing buffer size (power of two) ========
 #ifndef UART_TX_BUF_SIZE
-#define UART_TX_BUF_SIZE 128u // set to 128 or 256 as desired
+#define UART_TX_BUF_SIZE 256u // set to 128 or 256 as desired
 #endif
+// ======== Config: maximum devices reported by the startup bus scan ========
+#ifndef DS18B20_SEARCH_MAX_DEVICES
+#define DS18B20_SEARCH_MAX_DEVICES 8u
+#endif
+
+// ======== Selected device state (round-robin measurement) ========
+static uint8_t found_roms[DS18B20_SEARCH_MAX_DEVICES][8]; // ROMs found at startup
+static uint8_t found_count = 0; // how many devices were found
+static uint8_t select_index = 0; // index of the currently selected device
 
 // Validate that buffer size is a power of two for efficient masking operations
 #if (UART_TX_BUF_SIZE & (UART_TX_BUF_SIZE - 1u)) != 0
@@ -178,6 +187,74 @@ __STATIC_FORCEINLINE void uart_write_int(int value) {
 }
 
 /**
+ * @brief Enqueue one byte as two uppercase hexadecimal digits (best-effort)
+ * @param[in] b Byte to convert and transmit
+ */
+__STATIC_FORCEINLINE void uart_write_hex(uint8_t b) {
+    static const char hex[] = "0123456789ABCDEF";
+    (void)uart_tx_enqueue_byte((uint8_t)hex[(b >> 4) & 0x0F]);
+    (void)uart_tx_enqueue_byte((uint8_t)hex[b & 0x0F]);
+}
+
+/**
+ * @brief Device search callback - stores the ROM and prints it in hex
+ * @param[in] rom Pointer to the 8-byte ROM address (LSB first)
+ * @return 0 to continue the search
+ */
+static uint8_t device_found_sink(const uint8_t* rom) {
+    if (found_count < DS18B20_SEARCH_MAX_DEVICES) {
+        for (uint8_t i = 0; i < 8; i++) {
+            found_roms[found_count][i] = rom[i];
+        }
+        found_count++;
+    }
+    uart_write_str("  ROM: ");
+    for (uint8_t i = 0; i < 8; i++) {
+        uart_write_hex(rom[i]);
+        if (i != 7) (void)uart_tx_enqueue_byte(' ');
+    }
+    uart_write_str("\r\n");
+    return 0;
+}
+
+/**
+ * @brief Run the blocking bus scan once at startup and report the result
+ * @note The output is enqueued into the UART ring buffer; it is flushed by
+ *       uart_poll_tx() once the main loop starts. Up to ~5 devices fit in
+ *       the buffer before the output is truncated (best-effort).
+ */
+__STATIC_FORCEINLINE void search_devices_and_report(void) {
+    uart_write_str("Searching 1-Wire bus...\r\n");
+    uint8_t count = ds18b20_search_devices(device_found_sink, DS18B20_SEARCH_MAX_DEVICES);
+    if (count == 0) {
+        uart_write_str("No devices on the 1-Wire bus.\r\n");
+    } else {
+        uart_write_str("Found ");
+        uart_write_int(count);
+        uart_write_str(" device(s).\r\n");
+        select_index = 0;
+        ds18b20_select(found_roms[select_index]);
+        if (count == 1) {
+            uart_write_str("Measuring the single device.\r\n");
+        } else {
+            uart_write_str("Measuring devices in turn.\r\n");
+        }
+    }
+}
+
+/**
+ * @brief Print the ROM address of the currently selected device (best-effort)
+ */
+__STATIC_FORCEINLINE void print_selected_rom(void) {
+    uart_write_str(" -> ");
+    for (uint8_t i = 0; i < 8; i++) {
+        uart_write_hex(found_roms[select_index][i]);
+        if (i != 7) (void)uart_tx_enqueue_byte(' ');
+    }
+    uart_write_str("\r\n");
+}
+
+/**
  * @brief Weak implementation for DS18B20 measurement completion callback - handles result display
  * @param[in] temp Temperature value in tenths of degrees Celsius, or error code
  */
@@ -203,6 +280,13 @@ void ds18b20_complete(int16_t temp) {
         uart_write_str(" C"); // Units
         uart_write_str("\r\n"); // And newline
     }
+
+    // Round-robin: switch to the next device for the next measurement cycle
+    if (found_count > 1) {
+        select_index = (uint8_t)((select_index + 1u) % found_count);
+        ds18b20_select(found_roms[select_index]);
+        print_selected_rom();
+    }
 }
 
 /**
@@ -216,6 +300,7 @@ int main(void) {
     hardware_init(); // Initialize hardware peripherals (non-blocking)
     uart_write_str("DS18B20 demo starting...\r\n"); // Enqueue startup message to UART buffer
     ds18b20_init(); // Initialize DS18B20 driver (non-blocking)
+    search_devices_and_report(); // Blocking one-time bus scan (all sensors)
 
     for (;;) { // Main event loop (non-blocking, cooperative multitasking)
 

--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -554,11 +554,11 @@ static void ds18b20_restore(void) {
 
 /** @brief Search state machine phases */
 typedef enum {
-    DS18B20_SEARCH_RESET,     /**< reset scheduled; check presence, send 0xF0 */
-    DS18B20_SEARCH_CMD,       /**< 0xF0 sent; prepare first bit iteration */
+    DS18B20_SEARCH_RESET, /**< reset scheduled; check presence, send 0xF0 */
+    DS18B20_SEARCH_CMD, /**< 0xF0 sent; prepare first bit iteration */
     DS18B20_SEARCH_READ_PAIR, /**< id/cmp pair read; compute and write direction */
     DS18B20_SEARCH_WRITE_DIR, /**< direction written; advance bit counters */
-    DS18B20_SEARCH_DONE       /**< search finished; restore the driver state */
+    DS18B20_SEARCH_DONE /**< search finished; restore the driver state */
 } search_phase_t;
 
 /**
@@ -581,7 +581,7 @@ typedef struct {
 } search_ctx_t;
 
 /** @brief Global search context instance */
-static search_ctx_t s;
+static search_ctx_t search_ctx;
 
 /**
  * @brief Start a non-blocking device search
@@ -590,18 +590,18 @@ static search_ctx_t s;
  */
 void ds18b20_search_start(ds18b20_search_sink_t sink, uint8_t max_devices) {
     for (uint8_t i = 0; i < DS18B20_ROM_BYTES; i++) {
-        s.rom[i] = 0;
+        search_ctx.rom[i] = 0;
     }
-    s.sink = sink;
-    s.max = max_devices;
-    s.found = 0;
-    s.finished = 0;
-    s.last_discrepancy = 0;
+    search_ctx.sink = sink;
+    search_ctx.max = max_devices;
+    search_ctx.found = 0;
+    search_ctx.finished = 0;
+    search_ctx.last_discrepancy = 0;
     if (max_devices == 0) {
-        s.phase = DS18B20_SEARCH_DONE;
+        search_ctx.phase = DS18B20_SEARCH_DONE;
         return;
     }
-    s.phase = DS18B20_SEARCH_RESET;
+    search_ctx.phase = DS18B20_SEARCH_RESET;
     ds18b20_bus_reset(); // Schedule the first hardware operation
 }
 
@@ -610,15 +610,15 @@ void ds18b20_search_start(ds18b20_search_sink_t sink, uint8_t max_devices) {
  * @return 1 when the search is finished, 0 while still running
  */
 uint8_t ds18b20_search_poll(void) {
-    if (s.finished) {
+    if (search_ctx.finished) {
         return 1;
     }
 
-    if (s.phase == DS18B20_SEARCH_DONE) {
+    if (search_ctx.phase == DS18B20_SEARCH_DONE) {
         // No hardware operation is pending at the end of the search: hand the
         // timer back to the measurement state machine exactly once.
         ds18b20_restore();
-        s.finished = 1;
+        search_ctx.finished = 1;
         return 1;
     }
 
@@ -628,100 +628,100 @@ uint8_t ds18b20_search_poll(void) {
         return 0;
     }
 
-    switch (s.phase) {
+    switch (search_ctx.phase) {
     case DS18B20_SEARCH_RESET:
         // Reset completed: a presence pulse means at least one device is on
         // the bus, so start a new search pass with the Search ROM command.
         if (!ds18b20_bus_present()) {
-            s.phase = DS18B20_SEARCH_DONE;
+            search_ctx.phase = DS18B20_SEARCH_DONE;
             break;
         }
-        ds18b20_bus_encode_byte(s.pulses, DS18B20_SEARCH_ROM);
-        ds18b20_bus_write_slots(s.pulses, DS18B20_BITS_PER_BYTE);
-        s.phase = DS18B20_SEARCH_CMD;
+        ds18b20_bus_encode_byte(search_ctx.pulses, DS18B20_SEARCH_ROM);
+        ds18b20_bus_write_slots(search_ctx.pulses, DS18B20_BITS_PER_BYTE);
+        search_ctx.phase = DS18B20_SEARCH_CMD;
         break;
 
     case DS18B20_SEARCH_CMD:
         // 0xF0 sent: prepare the first bit iteration and read the id/cmp pair.
-        s.id_bit_number = 1;
-        s.last_zero = 0;
+        search_ctx.id_bit_number = 1;
+        search_ctx.last_zero = 0;
         ds18b20_bus_read_pair();
-        s.phase = DS18B20_SEARCH_READ_PAIR;
+        search_ctx.phase = DS18B20_SEARCH_READ_PAIR;
         break;
 
     case DS18B20_SEARCH_READ_PAIR: {
-        const uint8_t byte_idx = (s.id_bit_number - 1) / DS18B20_BITS_PER_BYTE;
-        const uint8_t mask = (uint8_t)(1u << ((s.id_bit_number - 1) % DS18B20_BITS_PER_BYTE));
+        const uint8_t byte_idx = (search_ctx.id_bit_number - 1) / DS18B20_BITS_PER_BYTE;
+        const uint8_t mask = (uint8_t)(1u << ((search_ctx.id_bit_number - 1) % DS18B20_BITS_PER_BYTE));
         const uint8_t id_bit = ds18b20_bus_pair_id();
         const uint8_t cmp_bit = ds18b20_bus_pair_cmp();
         uint8_t direction;
 
         if (id_bit && cmp_bit) {
             // No device follows this path - search tree exhausted
-            s.phase = DS18B20_SEARCH_DONE;
+            search_ctx.phase = DS18B20_SEARCH_DONE;
             break;
         }
         if (id_bit != cmp_bit) {
             // Single device on this path - its bit fixes the direction
             direction = id_bit;
-        } else if (s.id_bit_number < s.last_discrepancy) {
+        } else if (search_ctx.id_bit_number < search_ctx.last_discrepancy) {
             // Follow the previously taken path
-            direction = (s.rom[byte_idx] & mask) ? 1u : 0u;
+            direction = (search_ctx.rom[byte_idx] & mask) ? 1u : 0u;
             if (direction == 0) {
                 // Remember the last 0-branch taken at a discrepancy
-                s.last_zero = s.id_bit_number;
+                search_ctx.last_zero = search_ctx.id_bit_number;
             }
         } else {
             // At the discrepancy point take the '1' branch first
-            direction = (s.id_bit_number == s.last_discrepancy) ? 1u : 0u;
+            direction = (search_ctx.id_bit_number == search_ctx.last_discrepancy) ? 1u : 0u;
             if (direction == 0) {
                 // Remember the last 0-branch taken at a discrepancy
-                s.last_zero = s.id_bit_number;
+                search_ctx.last_zero = search_ctx.id_bit_number;
             }
         }
         if (direction) {
-            s.rom[byte_idx] |= mask;
+            search_ctx.rom[byte_idx] |= mask;
         } else {
-            s.rom[byte_idx] &= (uint8_t)~mask;
+            search_ctx.rom[byte_idx] &= (uint8_t)~mask;
         }
         ds18b20_bus_write_bit(direction);
-        s.phase = DS18B20_SEARCH_WRITE_DIR;
+        search_ctx.phase = DS18B20_SEARCH_WRITE_DIR;
         break;
     }
 
     case DS18B20_SEARCH_WRITE_DIR:
         // Direction written: advance to the next bit or finish the device.
-        s.id_bit_number++;
-        if (s.id_bit_number <= DS18B20_ROM_BITS) {
+        search_ctx.id_bit_number++;
+        if (search_ctx.id_bit_number <= DS18B20_ROM_BITS) {
             ds18b20_bus_read_pair();
-            s.phase = DS18B20_SEARCH_READ_PAIR;
+            search_ctx.phase = DS18B20_SEARCH_READ_PAIR;
             break;
         }
 
         // All 64 bits of the current ROM assembled - validate it.
-        s.last_discrepancy = s.last_zero;
-        if (ds18b20_crc8(s.rom, DS18B20_ROM_BYTES) != 0) {
-            s.phase = DS18B20_SEARCH_DONE;
+        search_ctx.last_discrepancy = search_ctx.last_zero;
+        if (ds18b20_crc8(search_ctx.rom, DS18B20_ROM_BYTES) != 0) {
+            search_ctx.phase = DS18B20_SEARCH_DONE;
             break;
         }
-        if (s.rom[0] == DS18B20_FAMILY_CODE) {
-            s.found++;
-            if (s.sink && s.sink(s.rom)) {
-                s.phase = DS18B20_SEARCH_DONE;
+        if (search_ctx.rom[0] == DS18B20_FAMILY_CODE) {
+            search_ctx.found++;
+            if (search_ctx.sink && search_ctx.sink(search_ctx.rom)) {
+                search_ctx.phase = DS18B20_SEARCH_DONE;
                 break;
             }
-            if (s.found >= s.max) {
-                s.phase = DS18B20_SEARCH_DONE;
+            if (search_ctx.found >= search_ctx.max) {
+                search_ctx.phase = DS18B20_SEARCH_DONE;
                 break;
             }
         }
-        if (s.last_discrepancy == 0) {
-            s.phase = DS18B20_SEARCH_DONE;
+        if (search_ctx.last_discrepancy == 0) {
+            search_ctx.phase = DS18B20_SEARCH_DONE;
             break;
         }
         // Another device may exist - run another search pass.
         ds18b20_bus_reset();
-        s.phase = DS18B20_SEARCH_RESET;
+        search_ctx.phase = DS18B20_SEARCH_RESET;
         break;
 
     default:
@@ -735,7 +735,7 @@ uint8_t ds18b20_search_poll(void) {
  * @brief Number of DS18B20 devices found (valid once the search finished)
  * @return Count of found devices
  */
-uint8_t ds18b20_search_count(void) { return s.found; }
+uint8_t ds18b20_search_count(void) { return search_ctx.found; }
 
 /**
  * @}

--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -95,10 +95,10 @@
         B2P(B, 4), B2P(B, 5), B2P(B, 6), B2P(B, 7)
 
 /** @brief DS18B20 Convert T command sequence in pulse duration format */
-static const uint8_t conv_cmd[] = {BYTE_TO_PULSES(0xCC), BYTE_TO_PULSES(0x44), 0};
+static const uint8_t conv_cmd[] = {BYTE_TO_PULSES(0xCC), BYTE_TO_PULSES(0x44)};
 
 /** @brief DS18B20 Read Scratchpad command sequence in pulse duration format */
-static const uint8_t read_cmd[] = {BYTE_TO_PULSES(0xCC), BYTE_TO_PULSES(0xBE), 0};
+static const uint8_t read_cmd[] = {BYTE_TO_PULSES(0xCC), BYTE_TO_PULSES(0xBE)};
 
 /**
  * @brief Force timer update event and wait for update flag - used for timer initialization
@@ -134,7 +134,7 @@ typedef struct {
     uint8_t current_state; /**< Current state of the state machine */
     uint8_t address_mode; /**< 0 = Skip ROM (all devices), non-zero = Match ROM */
     uint8_t selected_rom[DS18B20_ROM_BYTES]; /**< ROM of the selected device */
-    uint8_t addr_cmd[DS18B20_MATCH_SLOTS + 1]; /**< Pulse buffer for Match ROM command */
+    uint8_t addr_cmd[DS18B20_MATCH_SLOTS]; /**< Pulse buffer for Match ROM command */
 } DS18B20_ctx_t;
 
 /**
@@ -305,7 +305,8 @@ __STATIC_FORCEINLINE void reset_bus(void) {
  * @param[in] cmd Pointer to command sequence in pulse duration format
  * @param[in] slots Number of bit slots (bits) to transmit
  * @note Non-blocking - configures hardware to transmit command automatically.
- *       The buffer must hold `slots` pulse values plus a trailing 0 sentinel.
+ *       The buffer must hold `slots` pulse values; the first one is written
+ *       to CCR1 directly, the remaining `slots-1` are fed via DMA.
  */
 __STATIC_FORCEINLINE void send_command_n(const uint8_t* cmd, uint16_t slots) {
     // Configure timer for command transmission using DMA
@@ -323,7 +324,11 @@ __STATIC_FORCEINLINE void send_command_n(const uint8_t* cmd, uint16_t slots) {
     D14.CCR = 0; // Clear DMA configuration
     D14.CPAR = (uint32_t)&T1.CCR1; // DMA destination: output compare register
     D14.CMAR = (uint32_t)&cmd[1]; // DMA source: command data (skip first byte)
-    D14.CNDTR = slots; // Number of transfers
+    // One transfer per timer period, minus the first period whose CCR1 value
+    // was preloaded above. The timer still generates 'slots' DMA requests,
+    // but the DMA channel auto-disables after the final transfer (NDTR hits 0)
+    // and the remaining request is ignored.
+    D14.CNDTR = slots - 1; // Number of CCR1 updates needed
     D14.CCR = DMA_CCR(DIR, MINC, PSIZE_0, EN); // Enable DMA with memory increment
     T1.CR1 = TIM_CR1(OPM, CEN); // Start timer in one-pulse mode
 }
@@ -362,7 +367,6 @@ __STATIC_FORCEINLINE void build_addr_cmd(uint8_t cmd_byte) {
         p += DS18B20_BITS_PER_BYTE;
     }
     encode_byte_pulses(p, cmd_byte);
-    ctx.addr_cmd[DS18B20_MATCH_SLOTS] = 0; // DMA sentinel
 }
 
 /**

--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -70,6 +70,8 @@
 #define DS18B20_READ_SCRATCHPAD 0xBE
 /** @brief Total slots for Match ROM + 8-byte ROM + command */
 #define DS18B20_MATCH_SLOTS ((DS18B20_ROM_BYTES + 2) * DS18B20_BITS_PER_BYTE)
+/** @brief Slots for the invariant Match ROM + 8-byte ROM prefix (built on select) */
+#define DS18B20_PREFIX_SLOTS ((DS18B20_ROM_BYTES + 1) * DS18B20_BITS_PER_BYTE)
 /** @brief Threshold to distinguish short/long pulses (10µs) */
 #define SHORT_PULSE_MAX 0x0A
 /** @brief Number of DMA transfers for command transmission */
@@ -354,11 +356,12 @@ __STATIC_FORCEINLINE void encode_byte_pulses(uint8_t* out, uint8_t byte) {
 }
 
 /**
- * @brief Build the Match ROM command pulse sequence for the selected device
- * @param[in] cmd_byte Command byte to send after the ROM address
- * @note Fills ctx.addr_cmd with Match ROM (0x55) + selected ROM + command.
+ * @brief Build the invariant Match ROM prefix (0x55 + selected ROM)
+ * @note Fills the first DS18B20_PREFIX_SLOTS entries of ctx.addr_cmd.
+ *       The prefix depends only on the selected device, so it is built
+ *       once in ds18b20_select() and reused for every command.
  */
-__STATIC_FORCEINLINE void build_addr_cmd(uint8_t cmd_byte) {
+__STATIC_FORCEINLINE void build_addr_prefix(void) {
     uint8_t* p = ctx.addr_cmd;
     encode_byte_pulses(p, DS18B20_MATCH_ROM);
     p += DS18B20_BITS_PER_BYTE;
@@ -366,7 +369,16 @@ __STATIC_FORCEINLINE void build_addr_cmd(uint8_t cmd_byte) {
         encode_byte_pulses(p, ctx.selected_rom[i]);
         p += DS18B20_BITS_PER_BYTE;
     }
-    encode_byte_pulses(p, cmd_byte);
+}
+
+/**
+ * @brief Append one command byte to the pre-built Match ROM prefix
+ * @param[in] cmd_byte Command byte to send after the ROM address
+ * @note Requires build_addr_prefix() to have been called for the current
+ *       selected device. Only the last byte (8 slots) is re-encoded per call.
+ */
+__STATIC_FORCEINLINE void build_addr_cmd(uint8_t cmd_byte) {
+    encode_byte_pulses(&ctx.addr_cmd[DS18B20_PREFIX_SLOTS], cmd_byte);
 }
 
 /**
@@ -533,6 +545,7 @@ void ds18b20_select(const uint8_t* rom) {
     for (uint8_t i = 0; i < DS18B20_ROM_BYTES; i++) {
         ctx.selected_rom[i] = rom[i];
     }
+    build_addr_prefix(); // Build the invariant Match ROM prefix once per selection
     ctx.address_mode = 1;
 }
 

--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -696,6 +696,12 @@ uint8_t ds18b20_search_devices(uint8_t (*sink)(const uint8_t* rom), uint8_t max_
 
     // Repeat the search until every device has been enumerated
     while (!last_device && found < max_devices) {
+        // A reset + presence pulse is required before EVERY Search ROM pass:
+        // after a completed search transaction the found device is left
+        // selected (waiting for a function command) and the other devices go
+        // into a "not participating" state, so only a reset brings them all
+        // back to search mode. Omitting it stops the search after the first
+        // device (verified on 5x DS18B20 hardware).
         if (!search_reset()) {
             // No device answered - reset and stop the search
             last_discrepancy = 0;

--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -50,12 +50,19 @@
 #define ZERO_PULSE 60
 /** @brief Guard band between slots to prevent overlap due to bus rise time and DMA latency */
 #define GUARD_BAND 5
+/** @brief Number of bits in a byte */
+#define DS18B20_BITS_PER_BYTE 8
 /** @brief Total length of DS18B20 scratchpad in bytes */
 #define DS18B20_SCRATCHPAD_LEN 9
 /** @brief Total number of bits in DS18B20 scratchpad */
 #define DS18B20_SCRATCHPAD_BITS (DS18B20_SCRATCHPAD_LEN * DS18B20_BITS_PER_BYTE)
 /** @brief Total number of bits in a device ROM address */
 #define DS18B20_ROM_BITS (DS18B20_ROM_BYTES * DS18B20_BITS_PER_BYTE)
+/** @brief DS18B20 1-Wire command codes (internal protocol details) */
+#define DS18B20_SEARCH_ROM 0xF0 /**< Search ROM */
+#define DS18B20_MATCH_ROM 0x55 /**< Match ROM */
+#define DS18B20_READ_SCRATCHPAD 0xBE /**< Read Scratchpad */
+#define DS18B20_CONVERT_T 0x44 /**< Convert T */
 /** @brief Total slots for Match ROM + 8-byte ROM + command */
 #define DS18B20_MATCH_SLOTS ((DS18B20_ROM_BYTES + 2) * DS18B20_BITS_PER_BYTE)
 /** @brief Slots for the invariant Match ROM + 8-byte ROM prefix (built on select) */
@@ -172,7 +179,7 @@ __WEAK void ds18b20_complete(int16_t temp_tenths) {
  * @param[in] len Number of bytes to process
  * @return CRC-8 checksum value
  */
-uint8_t ds18b20_crc8(const uint8_t* data, uint8_t len) {
+static uint8_t ds18b20_crc8(const uint8_t* data, uint8_t len) {
     uint8_t crc = 0;
     // Process each byte in the buffer
     for (uint8_t i = 0; i < len; i++) {
@@ -400,121 +407,335 @@ __STATIC_FORCEINLINE void read_data(void) {
  */
 
 /**
- * @defgroup DS18B20_LowLevel DS18B20 Low-Level Blocking 1-Wire Primitives
- * @brief Blocking primitives for custom 1-Wire protocols (e.g., device search).
- * @note These busy-wait on the timer update flag. They reuse the same
- *       hardware-timed 1-Wire primitives as the state machine but wait for
- *       each operation synchronously. They MUST NOT be called while the
- *       non-blocking state machine is active (between ds18b20_init() and
- *       the first ds18b20_poll()). After using these, call ds18b20_restore()
- *       before starting ds18b20_poll().
+ * @defgroup DS18B20_Bus DS18B20 Internal 1-Wire Bus Primitives
+ * @brief Private non-blocking 1-Wire bus primitives used by the measurement
+ *        state machine and the built-in device search. Each function only
+ *        schedules a hardware-timed operation on TIM1/DMA and returns
+ *        immediately. They are internal to the driver and not exposed to the
+ *        application.
  * @{
  */
 
 /**
- * @brief Wait for the timer to finish its current one-shot operation
- * @note Busy-waits on the update flag. Used only by the low-level primitives.
+ * @brief Schedule a 1-Wire bus reset (presence pulse captured via DMA)
  */
-static void wait_timer_done(void) {
-    __DSB();
-    while (!(T1.SR & TIM_SR(UIF))) {
+static void ds18b20_bus_reset(void) { reset_bus(); }
+
+/**
+ * @brief Non-blocking completion check for the scheduled bus operation
+ * @return 1 if finished (update flag cleared), 0 while still running
+ */
+static uint8_t ds18b20_bus_done(void) {
+    if (T1.SR & TIM_SR(UIF)) {
+        T1.SR = 0;
+        return 1u;
     }
-    T1.SR = 0;
+    return 0u;
 }
 
 /**
- * @brief Write one bit to the 1-Wire bus as a single hardware-timed slot
- * @param[in] bit 1 = short low pulse (~5µs), 0 = long low pulse (~60µs)
- * @note Blocking: waits for the slot to finish before returning.
+ * @brief Check presence of the last scheduled bus reset
+ * @return 1 if at least one device answered, 0 otherwise
  */
-void ds18b20_write_bit(uint8_t bit) {
-    T1.RCR = 0; // Single slot, no repetition
-    T1.ARR = ONE_PULSE + ZERO_PULSE + GUARD_BAND; // Total bit slot time
-    T1.CCR1 = bit ? ONE_PULSE : ZERO_PULSE; // Pulse duration encodes the bit
-    // Configure channel 1 for output compare (drive bus low during the pulse)
-    T1.CCMR1 = TIM_CCMR1(OC1M_0, OC1M_1, OC1M_2);
-    T1.CCER = TIM_CCER(CC1E); // Enable output compare
-    T1.DIER = 0; // No DMA for a single bit slot
-    FORCE_UPDATE_EVENT(T1);
-    T1.CR1 = TIM_CR1(OPM, CEN); // Start timer in one-pulse mode
-    wait_timer_done();
+static uint8_t ds18b20_bus_present(void) { return (uint8_t)check_presence(); }
+
+/**
+ * @brief Encode a byte into pulse durations (ONE_PULSE for '1', ZERO_PULSE for '0')
+ * @param[out] out Output buffer (8 entries)
+ * @param[in] byte Byte value to encode
+ */
+static void ds18b20_bus_encode_byte(uint8_t* out, uint8_t byte) {
+    encode_byte_pulses(out, byte);
 }
 
 /**
- * @brief Write one byte to the 1-Wire bus, LSB first
- * @param[in] byte Byte value to transmit
- * @note Blocking: 8 sequential single-slot writes, waits between slots.
+ * @brief Schedule a write of `slots` bit slots
+ * @note Non-blocking: configures the hardware and returns. The pulses buffer
+ *       must stay valid until ds18b20_bus_done() reports completion, since
+ *       the DMA feeds CCR1 from it (except for a single slot, written directly).
  */
-void ds18b20_write_byte(uint8_t byte) {
-    for (uint8_t i = 0; i < DS18B20_BITS_PER_BYTE; i++) {
-        ds18b20_write_bit((byte >> i) & 0x01);
+static void ds18b20_bus_write_slots(const uint8_t* pulses, uint16_t slots) {
+    if (slots == 1) {
+        // Single slot: no DMA needed, avoids a zero-length DMA transaction
+        T1.RCR = 0; // Single slot, no repetition
+        T1.ARR = ONE_PULSE + ZERO_PULSE + GUARD_BAND; // Total bit slot time
+        T1.CCR1 = pulses[0]; // Pulse duration encodes the bit
+        // Configure channel 1 for output compare (drive bus low during the pulse)
+        T1.CCMR1 = TIM_CCMR1(OC1M_0, OC1M_1, OC1M_2);
+        T1.CCER = TIM_CCER(CC1E); // Enable output compare
+        T1.DIER = 0; // No DMA for a single bit slot
+        FORCE_UPDATE_EVENT(T1);
+        T1.CR1 = TIM_CR1(OPM, CEN); // Start timer in one-pulse mode
+        return;
     }
+    send_command_n(pulses, slots);
 }
 
 /**
- * @brief Read one bit from the 1-Wire bus as a single hardware-timed slot
- * @return The bit value read (0 or 1)
- * @note Blocking: waits for the slot to finish before returning.
+ * @brief Schedule a single-slot write of one raw bit (encodes 0/1 to a pulse)
+ * @param[in] bit Bit value to write (0 or 1)
  */
-uint8_t ds18b20_read_bit(void) {
-    volatile uint8_t sample = 0;
-    T1.RCR = 0; // Single slot, no repetition
+static void ds18b20_bus_write_bit(uint8_t bit) {
+    uint8_t pulse = bit ? (uint8_t)ONE_PULSE : (uint8_t)ZERO_PULSE;
+    ds18b20_bus_write_slots(&pulse, 1);
+}
+
+/**
+ * @brief Schedule a two-slot read for the Search ROM id/cmp bit pair
+ * @note Non-blocking: captures both slot timings into ctx.edge via DMA.
+ *       Read the decoded bits with ds18b20_bus_pair_id()/cmp() once
+ *       ds18b20_bus_done() reports completion.
+ */
+static void ds18b20_bus_read_pair(void) {
+    // Configure timer for a two-slot read (id_bit, cmp_bit)
+    T1.RCR = 1; // Two read slots, then a single update event
     T1.ARR = ONE_PULSE + ZERO_PULSE + GUARD_BAND; // Total bit slot time
     T1.CCR1 = ONE_PULSE; // Read pulse duration (ONE_PULSE µs)
     // Configure channel 1 for output compare (generate read pulse)
-    // Configure channel 2 for input capture (measure return pulse duration)
+    // Configure channel 2 for input capture (measure return pulse durations)
     T1.CCMR1 = TIM_CCMR1(OC1M_0, OC1M_1, OC1M_2, OC1PE, CC2S_1, IC2F_0, IC2F_1, IC2F_2);
     T1.CCER = TIM_CCER(CC1E, CC2E); // Enable both channels
     T1.DIER = TIM_DIER(CC2DE); // Enable DMA request on capture
     FORCE_UPDATE_EVENT(T1);
     T1.CCR1 = 0; // Clear output compare value
-    // Configure DMA to capture pulse duration into the local buffer
+    // Configure DMA to capture both slot timings into the edge buffer
     D13.CCR = 0; // Clear DMA configuration
     D13.CPAR = (uint32_t)&T1.CCR2; // DMA source: capture register
-    D13.CMAR = (uint32_t)&sample; // DMA destination: local sample buffer
-    D13.CNDTR = 1; // Number of transfers (1 bit)
-    D13.CCR = DMA_CCR(MINC, PSIZE_0, EN); // Enable DMA with memory increment
+    D13.CMAR = (uint32_t)ctx.edge; // DMA destination: edge timestamp buffer
+    D13.CNDTR = 2; // Number of transfers (id_bit, cmp_bit)
+    D13.CCR = DMA_CCR(MINC, PSIZE_0, MSIZE_0, EN); // Enable DMA with memory increment
     T1.CR1 = TIM_CR1(OPM, CEN); // Start timer in one-pulse mode
-    wait_timer_done();
-    // Decode using the same threshold as decode_scratchpad()
-    return (sample <= SHORT_PULSE_MAX) ? 1u : 0u;
 }
 
 /**
- * @brief Read one byte from the 1-Wire bus, LSB first
- * @return The byte value read
- * @note Blocking: 8 sequential single-slot reads, waits between slots.
+ * @brief Decode the id-bit of the last ds18b20_bus_read_pair()
+ * @return Bit value (0 or 1)
  */
-uint8_t ds18b20_read_byte(void) {
-    uint8_t byte = 0;
-    for (uint8_t i = 0; i < DS18B20_BITS_PER_BYTE; i++) {
-        if (ds18b20_read_bit()) {
-            byte |= (1u << i);
-        }
-    }
-    return byte;
+static uint8_t ds18b20_bus_pair_id(void) {
+    return (ctx.edge[0] <= SHORT_PULSE_MAX) ? 1u : 0u;
 }
 
 /**
- * @brief Perform a blocking 1-Wire reset and check for a presence pulse
- * @return 1 if at least one device answered the reset, 0 otherwise
+ * @brief Decode the cmp-bit of the last ds18b20_bus_read_pair()
+ * @return Bit value (0 or 1)
  */
-uint8_t ds18b20_reset(void) {
-    reset_bus();
-    wait_timer_done();
-    return check_presence();
+static uint8_t ds18b20_bus_pair_cmp(void) {
+    return (ctx.edge[1] <= SHORT_PULSE_MAX) ? 1u : 0u;
 }
 
 /**
- * @brief Restore the non-blocking state machine after using low-level primitives
- * @note Call this after finishing low-level operations and before starting
+ * @brief Restore the non-blocking state machine after using bus primitives
+ * @note Call this after finishing bus-level operations and before starting
  *       ds18b20_poll(). It re-primes the state machine so the first poll()
  *       begins a measurement cycle.
  */
-void ds18b20_restore(void) {
+static void ds18b20_restore(void) {
     T1.EGR = TIM_EGR(UG);
     __DSB();
 }
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DS18B20_Search_Internal DS18B20 Internal Non-Blocking Device Search
+ * @brief Maxim Search ROM (0xF0) state machine. The algorithm is inherently
+ *        sequential: the direction bit written at position i determines which
+ *        devices keep participating at position i+1, so the whole transaction
+ *        cannot be batched into a single DMA pass like the fixed measurement
+ *        sequence. Instead, the linear blocking loop is decomposed into a
+ *        compact state machine with loop counters kept in the context
+ *        (id_bit_number, last_discrepancy, ...). Each state performs exactly
+ *        one hardware-timed operation via the internal bus primitives, so a
+ *        poll call never blocks.
+ * @{
+ */
+
+/** @brief Search state machine phases */
+typedef enum {
+    DS18B20_SEARCH_RESET,     /**< reset scheduled; check presence, send 0xF0 */
+    DS18B20_SEARCH_CMD,       /**< 0xF0 sent; prepare first bit iteration */
+    DS18B20_SEARCH_READ_PAIR, /**< id/cmp pair read; compute and write direction */
+    DS18B20_SEARCH_WRITE_DIR, /**< direction written; advance bit counters */
+    DS18B20_SEARCH_DONE       /**< search finished; restore the driver state */
+} search_phase_t;
+
+/**
+ * @brief Non-blocking search context
+ * @note Holds the loop counters of the search algorithm; the persistent pulse
+ *       buffer (pulses) must stay valid across poll calls because the DMA
+ *       feeds CCR1 from it asynchronously while the 0xF0 command is sent.
+ */
+typedef struct {
+    search_phase_t phase; /**< Current phase of the search state machine */
+    uint8_t rom[DS18B20_ROM_BYTES]; /**< ROM being assembled (bit by bit) */
+    uint8_t pulses[DS18B20_BITS_PER_BYTE]; /**< Pulse buffer for the 0xF0 command */
+    uint8_t id_bit_number; /**< Current bit position (1..64) */
+    uint16_t last_discrepancy; /**< Last discrepancy point (Maxim algorithm) */
+    uint16_t last_zero; /**< Last position where the '0' branch was taken */
+    uint8_t found; /**< Number of DS18B20 devices found */
+    uint8_t max; /**< Maximum number of devices to report */
+    uint8_t finished; /**< 1 once the search has completed */
+    ds18b20_search_sink_t sink; /**< Per-device callback */
+} search_ctx_t;
+
+/** @brief Global search context instance */
+static search_ctx_t s;
+
+/**
+ * @brief Start a non-blocking device search
+ * @param[in] sink Callback invoked per found DS18B20 device (may be NULL)
+ * @param[in] max_devices Maximum number of devices to report (0 aborts)
+ */
+void ds18b20_search_start(ds18b20_search_sink_t sink, uint8_t max_devices) {
+    for (uint8_t i = 0; i < DS18B20_ROM_BYTES; i++) {
+        s.rom[i] = 0;
+    }
+    s.sink = sink;
+    s.max = max_devices;
+    s.found = 0;
+    s.finished = 0;
+    s.last_discrepancy = 0;
+    if (max_devices == 0) {
+        s.phase = DS18B20_SEARCH_DONE;
+        return;
+    }
+    s.phase = DS18B20_SEARCH_RESET;
+    ds18b20_bus_reset(); // Schedule the first hardware operation
+}
+
+/**
+ * @brief Advance the non-blocking device search
+ * @return 1 when the search is finished, 0 while still running
+ */
+uint8_t ds18b20_search_poll(void) {
+    if (s.finished) {
+        return 1;
+    }
+
+    if (s.phase == DS18B20_SEARCH_DONE) {
+        // No hardware operation is pending at the end of the search: hand the
+        // timer back to the measurement state machine exactly once.
+        ds18b20_restore();
+        s.finished = 1;
+        return 1;
+    }
+
+    // Wait for the currently scheduled hardware operation to complete.
+    // This is a non-blocking poll, not a busy-wait.
+    if (!ds18b20_bus_done()) {
+        return 0;
+    }
+
+    switch (s.phase) {
+    case DS18B20_SEARCH_RESET:
+        // Reset completed: a presence pulse means at least one device is on
+        // the bus, so start a new search pass with the Search ROM command.
+        if (!ds18b20_bus_present()) {
+            s.phase = DS18B20_SEARCH_DONE;
+            break;
+        }
+        ds18b20_bus_encode_byte(s.pulses, DS18B20_SEARCH_ROM);
+        ds18b20_bus_write_slots(s.pulses, DS18B20_BITS_PER_BYTE);
+        s.phase = DS18B20_SEARCH_CMD;
+        break;
+
+    case DS18B20_SEARCH_CMD:
+        // 0xF0 sent: prepare the first bit iteration and read the id/cmp pair.
+        s.id_bit_number = 1;
+        s.last_zero = 0;
+        ds18b20_bus_read_pair();
+        s.phase = DS18B20_SEARCH_READ_PAIR;
+        break;
+
+    case DS18B20_SEARCH_READ_PAIR: {
+        const uint8_t byte_idx = (s.id_bit_number - 1) / DS18B20_BITS_PER_BYTE;
+        const uint8_t mask = (uint8_t)(1u << ((s.id_bit_number - 1) % DS18B20_BITS_PER_BYTE));
+        const uint8_t id_bit = ds18b20_bus_pair_id();
+        const uint8_t cmp_bit = ds18b20_bus_pair_cmp();
+        uint8_t direction;
+
+        if (id_bit && cmp_bit) {
+            // No device follows this path - search tree exhausted
+            s.phase = DS18B20_SEARCH_DONE;
+            break;
+        }
+        if (id_bit != cmp_bit) {
+            // Single device on this path - its bit fixes the direction
+            direction = id_bit;
+        } else if (s.id_bit_number < s.last_discrepancy) {
+            // Follow the previously taken path
+            direction = (s.rom[byte_idx] & mask) ? 1u : 0u;
+            if (direction == 0) {
+                // Remember the last 0-branch taken at a discrepancy
+                s.last_zero = s.id_bit_number;
+            }
+        } else {
+            // At the discrepancy point take the '1' branch first
+            direction = (s.id_bit_number == s.last_discrepancy) ? 1u : 0u;
+            if (direction == 0) {
+                // Remember the last 0-branch taken at a discrepancy
+                s.last_zero = s.id_bit_number;
+            }
+        }
+        if (direction) {
+            s.rom[byte_idx] |= mask;
+        } else {
+            s.rom[byte_idx] &= (uint8_t)~mask;
+        }
+        ds18b20_bus_write_bit(direction);
+        s.phase = DS18B20_SEARCH_WRITE_DIR;
+        break;
+    }
+
+    case DS18B20_SEARCH_WRITE_DIR:
+        // Direction written: advance to the next bit or finish the device.
+        s.id_bit_number++;
+        if (s.id_bit_number <= DS18B20_ROM_BITS) {
+            ds18b20_bus_read_pair();
+            s.phase = DS18B20_SEARCH_READ_PAIR;
+            break;
+        }
+
+        // All 64 bits of the current ROM assembled - validate it.
+        s.last_discrepancy = s.last_zero;
+        if (ds18b20_crc8(s.rom, DS18B20_ROM_BYTES) != 0) {
+            s.phase = DS18B20_SEARCH_DONE;
+            break;
+        }
+        if (s.rom[0] == DS18B20_FAMILY_CODE) {
+            s.found++;
+            if (s.sink && s.sink(s.rom)) {
+                s.phase = DS18B20_SEARCH_DONE;
+                break;
+            }
+            if (s.found >= s.max) {
+                s.phase = DS18B20_SEARCH_DONE;
+                break;
+            }
+        }
+        if (s.last_discrepancy == 0) {
+            s.phase = DS18B20_SEARCH_DONE;
+            break;
+        }
+        // Another device may exist - run another search pass.
+        ds18b20_bus_reset();
+        s.phase = DS18B20_SEARCH_RESET;
+        break;
+
+    default:
+        break;
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Number of DS18B20 devices found (valid once the search finished)
+ * @return Count of found devices
+ */
+uint8_t ds18b20_search_count(void) { return s.found; }
 
 /**
  * @}
@@ -549,7 +770,7 @@ void ds18b20_init(void) {
  *       plus the device address before each command, so only that device
  *       responds. Pass NULL (or a freshly initialised driver) to keep the
  *       legacy single-sensor Skip ROM behaviour. The address should come from
- *       a bus search using the low-level primitives.
+ *       the non-blocking device search (ds18b20_search_*).
  */
 void ds18b20_select(const uint8_t* rom) {
     if (rom == 0) {

--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -720,8 +720,7 @@ uint8_t ds18b20_search_devices(uint8_t (*sink)(const uint8_t* rom), uint8_t max_
         // back to search mode. Omitting it stops the search after the first
         // device (verified on 5x DS18B20 hardware).
         if (!search_reset()) {
-            // No device answered - reset and stop the search
-            last_discrepancy = 0;
+            // No device answered - stop the search
             break;
         }
 

--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -52,22 +52,10 @@
 #define GUARD_BAND 5
 /** @brief Total length of DS18B20 scratchpad in bytes */
 #define DS18B20_SCRATCHPAD_LEN 9
-/** @brief Standard 8 bits per byte */
-#define DS18B20_BITS_PER_BYTE 8
 /** @brief Total number of bits in DS18B20 scratchpad */
 #define DS18B20_SCRATCHPAD_BITS (DS18B20_SCRATCHPAD_LEN * DS18B20_BITS_PER_BYTE)
-/** @brief Number of bytes in a device ROM address */
-#define DS18B20_ROM_BYTES 8
 /** @brief Total number of bits in a device ROM address */
 #define DS18B20_ROM_BITS (DS18B20_ROM_BYTES * DS18B20_BITS_PER_BYTE)
-/** @brief DS18B20 Search ROM command */
-#define DS18B20_SEARCH_ROM 0xF0
-/** @brief DS18B20 Match ROM command */
-#define DS18B20_MATCH_ROM 0x55
-/** @brief DS18B20 Convert T command */
-#define DS18B20_CONVERT_T 0x44
-/** @brief DS18B20 Read Scratchpad command */
-#define DS18B20_READ_SCRATCHPAD 0xBE
 /** @brief Total slots for Match ROM + 8-byte ROM + command */
 #define DS18B20_MATCH_SLOTS ((DS18B20_ROM_BYTES + 2) * DS18B20_BITS_PER_BYTE)
 /** @brief Slots for the invariant Match ROM + 8-byte ROM prefix (built on select) */
@@ -184,7 +172,7 @@ __WEAK void ds18b20_complete(int16_t temp_tenths) {
  * @param[in] len Number of bytes to process
  * @return CRC-8 checksum value
  */
-__STATIC_FORCEINLINE uint8_t crc8_calc(const uint8_t* data, uint8_t len) {
+uint8_t ds18b20_crc8(const uint8_t* data, uint8_t len) {
     uint8_t crc = 0;
     // Process each byte in the buffer
     for (uint8_t i = 0; i < len; i++) {
@@ -205,7 +193,7 @@ __STATIC_FORCEINLINE uint8_t crc8_calc(const uint8_t* data, uint8_t len) {
  * @return CRC8 checksum value
  */
 __STATIC_FORCEINLINE uint8_t check_scratchpad_crc(void) {
-    return crc8_calc(ctx.scratchpad, DS18B20_CRC8_BYTES);
+    return ds18b20_crc8(ctx.scratchpad, DS18B20_CRC8_BYTES);
 }
 
 /**
@@ -412,19 +400,22 @@ __STATIC_FORCEINLINE void read_data(void) {
  */
 
 /**
- * @defgroup DS18B20_Blocking_Search DS18B20 Blocking Bus Search
- * @brief One-time, blocking helpers used by ds18b20_search_devices()
- * @note These are the only functions in the driver that busy-wait on UIF.
- *       They reuse the same hardware-timed 1-Wire primitives as the state
- *       machine but wait for each operation synchronously.
+ * @defgroup DS18B20_LowLevel DS18B20 Low-Level Blocking 1-Wire Primitives
+ * @brief Blocking primitives for custom 1-Wire protocols (e.g., device search).
+ * @note These busy-wait on the timer update flag. They reuse the same
+ *       hardware-timed 1-Wire primitives as the state machine but wait for
+ *       each operation synchronously. They MUST NOT be called while the
+ *       non-blocking state machine is active (between ds18b20_init() and
+ *       the first ds18b20_poll()). After using these, call ds18b20_restore()
+ *       before starting ds18b20_poll().
  * @{
  */
 
 /**
  * @brief Wait for the timer to finish its current one-shot operation
- * @note Busy-waits on the update flag. Used only by the blocking search.
+ * @note Busy-waits on the update flag. Used only by the low-level primitives.
  */
-__STATIC_FORCEINLINE void wait_timer_done(void) {
+static void wait_timer_done(void) {
     __DSB();
     while (!(T1.SR & TIM_SR(UIF))) {
     }
@@ -436,7 +427,7 @@ __STATIC_FORCEINLINE void wait_timer_done(void) {
  * @param[in] bit 1 = short low pulse (~5µs), 0 = long low pulse (~60µs)
  * @note Blocking: waits for the slot to finish before returning.
  */
-__STATIC_FORCEINLINE void write_bit(uint8_t bit) {
+void ds18b20_write_bit(uint8_t bit) {
     T1.RCR = 0; // Single slot, no repetition
     T1.ARR = ONE_PULSE + ZERO_PULSE + GUARD_BAND; // Total bit slot time
     T1.CCR1 = bit ? ONE_PULSE : ZERO_PULSE; // Pulse duration encodes the bit
@@ -454,52 +445,75 @@ __STATIC_FORCEINLINE void write_bit(uint8_t bit) {
  * @param[in] byte Byte value to transmit
  * @note Blocking: 8 sequential single-slot writes, waits between slots.
  */
-__STATIC_FORCEINLINE void send_byte(uint8_t byte) {
+void ds18b20_write_byte(uint8_t byte) {
     for (uint8_t i = 0; i < DS18B20_BITS_PER_BYTE; i++) {
-        write_bit((byte >> i) & 0x01);
+        ds18b20_write_bit((byte >> i) & 0x01);
     }
 }
 
 /**
- * @brief Read two consecutive bits from the 1-Wire bus (Search ROM pair)
- * @param[out] id_bit First bit read in the slot
- * @param[out] cmp_bit Second (complement) bit read in the same slot
- * @note Blocking: runs two read slots (RCR=1) in a single timer transaction
- *       and decodes the captured pulse widths like read_data() does.
+ * @brief Read one bit from the 1-Wire bus as a single hardware-timed slot
+ * @return The bit value read (0 or 1)
+ * @note Blocking: waits for the slot to finish before returning.
  */
-__STATIC_FORCEINLINE void read_2bits(uint8_t* id_bit, uint8_t* cmp_bit) {
-    volatile uint8_t samples[2];
-    T1.RCR = 1; // Two read slots
+uint8_t ds18b20_read_bit(void) {
+    volatile uint8_t sample = 0;
+    T1.RCR = 0; // Single slot, no repetition
     T1.ARR = ONE_PULSE + ZERO_PULSE + GUARD_BAND; // Total bit slot time
     T1.CCR1 = ONE_PULSE; // Read pulse duration (ONE_PULSE µs)
     // Configure channel 1 for output compare (generate read pulse)
-    // Configure channel 2 for input capture (measure return pulse durations)
+    // Configure channel 2 for input capture (measure return pulse duration)
     T1.CCMR1 = TIM_CCMR1(OC1M_0, OC1M_1, OC1M_2, OC1PE, CC2S_1, IC2F_0, IC2F_1, IC2F_2);
     T1.CCER = TIM_CCER(CC1E, CC2E); // Enable both channels
     T1.DIER = TIM_DIER(CC2DE); // Enable DMA request on capture
     FORCE_UPDATE_EVENT(T1);
     T1.CCR1 = 0; // Clear output compare value
-    // Configure DMA to capture pulse durations into the local buffer
+    // Configure DMA to capture pulse duration into the local buffer
     D13.CCR = 0; // Clear DMA configuration
-    D13.CPAR = (uint32_t)&T1.CCR2; // DMA destination: capture register
-    D13.CMAR = (uint32_t)samples; // DMA source: local sample buffer
-    D13.CNDTR = 2; // Number of transfers (2 bits)
+    D13.CPAR = (uint32_t)&T1.CCR2; // DMA source: capture register
+    D13.CMAR = (uint32_t)&sample; // DMA destination: local sample buffer
+    D13.CNDTR = 1; // Number of transfers (1 bit)
     D13.CCR = DMA_CCR(MINC, PSIZE_0, EN); // Enable DMA with memory increment
     T1.CR1 = TIM_CR1(OPM, CEN); // Start timer in one-pulse mode
     wait_timer_done();
     // Decode using the same threshold as decode_scratchpad()
-    *id_bit = (samples[0] <= SHORT_PULSE_MAX) ? 1u : 0u;
-    *cmp_bit = (samples[1] <= SHORT_PULSE_MAX) ? 1u : 0u;
+    return (sample <= SHORT_PULSE_MAX) ? 1u : 0u;
+}
+
+/**
+ * @brief Read one byte from the 1-Wire bus, LSB first
+ * @return The byte value read
+ * @note Blocking: 8 sequential single-slot reads, waits between slots.
+ */
+uint8_t ds18b20_read_byte(void) {
+    uint8_t byte = 0;
+    for (uint8_t i = 0; i < DS18B20_BITS_PER_BYTE; i++) {
+        if (ds18b20_read_bit()) {
+            byte |= (1u << i);
+        }
+    }
+    return byte;
 }
 
 /**
  * @brief Perform a blocking 1-Wire reset and check for a presence pulse
  * @return 1 if at least one device answered the reset, 0 otherwise
  */
-__STATIC_FORCEINLINE uint8_t search_reset(void) {
+uint8_t ds18b20_reset(void) {
     reset_bus();
     wait_timer_done();
     return check_presence();
+}
+
+/**
+ * @brief Restore the non-blocking state machine after using low-level primitives
+ * @note Call this after finishing low-level operations and before starting
+ *       ds18b20_poll(). It re-primes the state machine so the first poll()
+ *       begins a measurement cycle.
+ */
+void ds18b20_restore(void) {
+    T1.EGR = TIM_EGR(UG);
+    __DSB();
 }
 
 /**
@@ -535,7 +549,7 @@ void ds18b20_init(void) {
  *       plus the device address before each command, so only that device
  *       responds. Pass NULL (or a freshly initialised driver) to keep the
  *       legacy single-sensor Skip ROM behaviour. The address should come from
- *       ds18b20_search_devices().
+ *       a bus search using the low-level primitives.
  */
 void ds18b20_select(const uint8_t* rom) {
     if (rom == 0) {
@@ -676,124 +690,6 @@ void ds18b20_poll(void) {
         ctx.current_state = 0;
         break;
     }
-}
-
-/**
- * @brief Kick the non-blocking state machine so the next poll() starts a cycle
- * @note The blocking search clears the timer update flag on every operation,
- *       which would otherwise leave the state machine waiting forever for the
- *       UIF that idles in state 0. Setting UIF here restores the original
- *       behaviour where the first poll() after startup began a measurement.
- */
-__STATIC_FORCEINLINE void kick_state_machine(void) {
-    T1.EGR = TIM_EGR(UG);
-    __DSB();
-}
-
-/**
- * @brief Search the 1-Wire bus and report every device ROM address
- * @param[in] sink Callback invoked once per found device with its 64-bit ROM
- *                 address (LSB first). May be NULL to only count devices.
- *                 Return non-zero from the callback to stop the search early.
- * @param[in] max_devices Maximum number of devices to report (0 aborts)
- * @return Number of devices found on the bus
- * @note Blocking - intended for one-time use at startup. Implements the
- *       standard Maxim 1-Wire Search ROM (0xF0) algorithm with the
- *       last-discrepancy method and CRC-8 validation.
- */
-uint8_t ds18b20_search_devices(uint8_t (*sink)(const uint8_t* rom), uint8_t max_devices) {
-    uint8_t rom[DS18B20_ROM_BYTES] = {0};
-    uint8_t found = 0;
-    uint8_t last_device = 0;
-    uint16_t last_discrepancy = 0;
-
-    if (max_devices == 0) {
-        return 0;
-    }
-
-    // Repeat the search until every device has been enumerated
-    while (!last_device && found < max_devices) {
-        // A reset + presence pulse is required before EVERY Search ROM pass:
-        // after a completed search transaction the found device is left
-        // selected (waiting for a function command) and the other devices go
-        // into a "not participating" state, so only a reset brings them all
-        // back to search mode. Omitting it stops the search after the first
-        // device (verified on 5x DS18B20 hardware).
-        if (!search_reset()) {
-            // No device answered - stop the search
-            break;
-        }
-
-        send_byte(DS18B20_SEARCH_ROM);
-
-        uint16_t id_bit_number = 1;
-        uint16_t last_zero = 0;
-        for (uint8_t byte_idx = 0; byte_idx < DS18B20_ROM_BYTES; byte_idx++) {
-            uint8_t mask = 1;
-            for (uint8_t bit_idx = 0; bit_idx < DS18B20_BITS_PER_BYTE; bit_idx++) {
-                uint8_t id_bit, cmp_bit, direction;
-                read_2bits(&id_bit, &cmp_bit);
-                if (id_bit && cmp_bit) {
-                    // No device follows this path - search tree exhausted
-                    kick_state_machine();
-                    return found;
-                }
-                if (id_bit != cmp_bit) {
-                    // Single device on this path - its bit fixes the direction
-                    direction = id_bit;
-                } else if (id_bit_number < last_discrepancy) {
-                    // Follow the previously taken path
-                    direction = (rom[byte_idx] & mask) ? 1u : 0u;
-                    if (direction == 0) {
-                        // Remember the last 0-branch taken at a discrepancy
-                        last_zero = id_bit_number;
-                    }
-                } else {
-                    // At the discrepancy point take the '1' branch first
-                    direction = (id_bit_number == last_discrepancy) ? 1u : 0u;
-                    if (direction == 0) {
-                        // Remember the last 0-branch taken at a discrepancy
-                        last_zero = id_bit_number;
-                    }
-                }
-                if (direction) {
-                    rom[byte_idx] |= mask;
-                } else {
-                    rom[byte_idx] &= (uint8_t)~mask;
-                }
-                write_bit(direction);
-                id_bit_number++;
-                mask <<= 1;
-            }
-        }
-        last_discrepancy = last_zero;
-
-        // Validate the assembled ROM address
-        if (crc8_calc(rom, DS18B20_ROM_BYTES) != 0) {
-            break;
-        }
-
-        // Only report DS18B20 devices; other 1-Wire families share the bus
-        // but are not temperature sensors and must not be measured as one.
-        if (rom[0] != DS18B20_FAMILY_CODE) {
-            if (last_discrepancy == 0) {
-                last_device = 1; // This was the last device on the bus
-            }
-            continue;
-        }
-
-        found++;
-        if (sink && sink(rom)) {
-            break; // Callback requested an early stop
-        }
-        if (last_discrepancy == 0) {
-            last_device = 1; // This was the last device on the bus
-        }
-    }
-
-    // Kick the non-blocking state machine (see kick_state_machine)
-    kick_state_machine();
-    return found;
 }
 
 /**

--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -751,6 +751,15 @@ uint8_t ds18b20_search_devices(uint8_t (*sink)(const uint8_t* rom), uint8_t max_
             break;
         }
 
+        // Only report DS18B20 devices; other 1-Wire families share the bus
+        // but are not temperature sensors and must not be measured as one.
+        if (rom[0] != DS18B20_FAMILY_CODE) {
+            if (last_discrepancy == 0) {
+                last_device = 1; // This was the last device on the bus
+            }
+            continue;
+        }
+
         found++;
         if (sink && sink(rom)) {
             break; // Callback requested an early stop

--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -8,36 +8,6 @@
  */
 
 /**
- * @brief DS18B20 driver context structure using union for memory efficiency
- * @note Different stages of communication use the same memory for different purposes
- */
-typedef struct {
-    union {
-        volatile uint16_t edge[36]; /**< Edge timestamps for presence detection */
-        volatile uint8_t pulse[72]; /**< Pulse durations for data decoding */
-        uint8_t scratchpad[9]; /**< Sensor scratchpad data */
-        uint64_t fill_union; /**< Utility field for filling the union */
-    };
-    uint8_t current_state; /**< Current state of the state machine */
-} DS18B20_ctx_t;
-
-/**
- * @}
- */
-
-/**
- * @defgroup DS18B20_Private_Variables DS18B20 Private Variables
- * @{
- */
-
-/** @brief Global driver context instance */
-static DS18B20_ctx_t ctx;
-
-/**
- * @}
- */
-
-/**
  * @defgroup DS18B20_Private_Constants DS18B20 Private Constants
  * @{
  */
@@ -92,6 +62,14 @@ static DS18B20_ctx_t ctx;
 #define DS18B20_ROM_BITS (DS18B20_ROM_BYTES * DS18B20_BITS_PER_BYTE)
 /** @brief DS18B20 Search ROM command */
 #define DS18B20_SEARCH_ROM 0xF0
+/** @brief DS18B20 Match ROM command */
+#define DS18B20_MATCH_ROM 0x55
+/** @brief DS18B20 Convert T command */
+#define DS18B20_CONVERT_T 0x44
+/** @brief DS18B20 Read Scratchpad command */
+#define DS18B20_READ_SCRATCHPAD 0xBE
+/** @brief Total slots for Match ROM + 8-byte ROM + command */
+#define DS18B20_MATCH_SLOTS ((DS18B20_ROM_BYTES + 2) * DS18B20_BITS_PER_BYTE)
 /** @brief Threshold to distinguish short/long pulses (10µs) */
 #define SHORT_PULSE_MAX 0x0A
 /** @brief Number of DMA transfers for command transmission */
@@ -132,6 +110,44 @@ static const uint8_t read_cmd[] = {BYTE_TO_PULSES(0xCC), BYTE_TO_PULSES(0xBE), 0
         __DSB();                \
         (T).SR &= ~TIM_SR(UIF); \
     } while (0)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DS18B20_Private_Types DS18B20 Private Types
+ * @{
+ */
+
+/**
+ * @brief DS18B20 driver context structure using union for memory efficiency
+ * @note Different stages of communication use the same memory for different purposes
+ */
+typedef struct {
+    union {
+        volatile uint16_t edge[36]; /**< Edge timestamps for presence detection */
+        volatile uint8_t pulse[72]; /**< Pulse durations for data decoding */
+        uint8_t scratchpad[9]; /**< Sensor scratchpad data */
+        uint64_t fill_union; /**< Utility field for filling the union */
+    };
+    uint8_t current_state; /**< Current state of the state machine */
+    uint8_t address_mode; /**< 0 = Skip ROM (all devices), non-zero = Match ROM */
+    uint8_t selected_rom[DS18B20_ROM_BYTES]; /**< ROM of the selected device */
+    uint8_t addr_cmd[DS18B20_MATCH_SLOTS + 1]; /**< Pulse buffer for Match ROM command */
+} DS18B20_ctx_t;
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup DS18B20_Private_Variables DS18B20 Private Variables
+ * @{
+ */
+
+/** @brief Global driver context instance */
+static DS18B20_ctx_t ctx;
 
 /**
  * @}
@@ -285,13 +301,15 @@ __STATIC_FORCEINLINE void reset_bus(void) {
 }
 
 /**
- * @brief Transmit command sequence to DS18B20 using DMA
+ * @brief Transmit a command sequence of arbitrary length to DS18B20 using DMA
  * @param[in] cmd Pointer to command sequence in pulse duration format
- * @note Non-blocking - configures hardware to transmit command automatically
+ * @param[in] slots Number of bit slots (bits) to transmit
+ * @note Non-blocking - configures hardware to transmit command automatically.
+ *       The buffer must hold `slots` pulse values plus a trailing 0 sentinel.
  */
-__STATIC_FORCEINLINE void send_command(const uint8_t* cmd) {
+__STATIC_FORCEINLINE void send_command_n(const uint8_t* cmd, uint16_t slots) {
     // Configure timer for command transmission using DMA
-    T1.RCR = DS18B20_DMA_TRANSFERS - 1; // Number of repetitions (16 transfers)
+    T1.RCR = slots - 1; // Number of repetitions (one slot per transfer)
     T1.ARR = ONE_PULSE + ZERO_PULSE + GUARD_BAND; // Total bit slot time
     T1.CCR1 = cmd[0]; // First pulse duration
     T1.CCR4 = ONE_PULSE + ZERO_PULSE; // Update trigger time
@@ -305,9 +323,46 @@ __STATIC_FORCEINLINE void send_command(const uint8_t* cmd) {
     D14.CCR = 0; // Clear DMA configuration
     D14.CPAR = (uint32_t)&TIM1->CCR1; // DMA destination: output compare register
     D14.CMAR = (uint32_t)&cmd[1]; // DMA source: command data (skip first byte)
-    D14.CNDTR = DS18B20_DMA_TRANSFERS; // Number of transfers
+    D14.CNDTR = slots; // Number of transfers
     D14.CCR = DMA_CCR(DIR, MINC, PSIZE_0, EN); // Enable DMA with memory increment
     T1.CR1 = TIM_CR1(OPM, CEN); // Start timer in one-pulse mode
+}
+
+/**
+ * @brief Transmit a two-byte command sequence (Skip ROM + command) using DMA
+ * @param[in] cmd Pointer to command sequence in pulse duration format
+ * @note Non-blocking - configures hardware to transmit command automatically
+ */
+__STATIC_FORCEINLINE void send_command(const uint8_t* cmd) {
+    send_command_n(cmd, DS18B20_DMA_TRANSFERS);
+}
+
+/**
+ * @brief Encode a byte into pulse durations (ONE_PULSE for '1', ZERO_PULSE for '0')
+ * @param[out] out Output buffer (8 entries)
+ * @param[in] byte Byte value to encode
+ */
+__STATIC_FORCEINLINE void encode_byte_pulses(uint8_t* out, uint8_t byte) {
+    for (uint8_t i = 0; i < DS18B20_BITS_PER_BYTE; i++) {
+        out[i] = (byte & (1u << i)) ? (uint8_t)ONE_PULSE : (uint8_t)ZERO_PULSE;
+    }
+}
+
+/**
+ * @brief Build the Match ROM command pulse sequence for the selected device
+ * @param[in] cmd_byte Command byte to send after the ROM address
+ * @note Fills ctx.addr_cmd with Match ROM (0x55) + selected ROM + command.
+ */
+__STATIC_FORCEINLINE void build_addr_cmd(uint8_t cmd_byte) {
+    uint8_t* p = ctx.addr_cmd;
+    encode_byte_pulses(p, DS18B20_MATCH_ROM);
+    p += DS18B20_BITS_PER_BYTE;
+    for (uint8_t i = 0; i < DS18B20_ROM_BYTES; i++) {
+        encode_byte_pulses(p, ctx.selected_rom[i]);
+        p += DS18B20_BITS_PER_BYTE;
+    }
+    encode_byte_pulses(p, cmd_byte);
+    ctx.addr_cmd[DS18B20_MATCH_SLOTS] = 0; // DMA sentinel
 }
 
 /**
@@ -457,6 +512,27 @@ void ds18b20_init(void) {
 }
 
 /**
+ * @brief Select which DS18B20 device to measure by its ROM address
+ * @param[in] rom Pointer to the 8-byte ROM address (LSB first), or NULL to
+ *                return to Skip ROM (broadcast) addressing
+ * @note With a non-NULL address, the state machine sends Match ROM (0x55)
+ *       plus the device address before each command, so only that device
+ *       responds. Pass NULL (or a freshly initialised driver) to keep the
+ *       legacy single-sensor Skip ROM behaviour. The address should come from
+ *       ds18b20_search_devices().
+ */
+void ds18b20_select(const uint8_t* rom) {
+    if (rom == 0) {
+        ctx.address_mode = 0;
+        return;
+    }
+    for (uint8_t i = 0; i < DS18B20_ROM_BYTES; i++) {
+        ctx.selected_rom[i] = rom[i];
+    }
+    ctx.address_mode = 1;
+}
+
+/**
  * @brief Main state machine function - must be called periodically from main loop
  * @note Non-blocking state machine that advances 1-Wire communication state
  * @note Uses timer update interrupt flag to determine when operations complete
@@ -491,8 +567,14 @@ void ds18b20_poll(void) {
     case 2: // CONVERT - Check presence and send convert command
         // Verify DS18B20 presence using captured edge timestamps
         if (check_presence()) {
-            // Device present - send temperature conversion command
-            send_command(conv_cmd);
+            // Device present - send temperature conversion command,
+            // addressing all devices (Skip ROM) or the selected one (Match ROM)
+            if (ctx.address_mode) {
+                build_addr_cmd(DS18B20_CONVERT_T);
+                send_command_n(ctx.addr_cmd, DS18B20_MATCH_SLOTS);
+            } else {
+                send_command(conv_cmd);
+            }
             // Transition to WAIT state to allow conversion time
             ctx.current_state = 3;
         } else {
@@ -522,8 +604,14 @@ void ds18b20_poll(void) {
     case 5: // REQUEST - Check presence and send read command
         // Verify DS18B20 presence again
         if (check_presence()) {
-            // Device present - send read scratchpad command
-            send_command(read_cmd);
+            // Device present - send read scratchpad command,
+            // addressing all devices (Skip ROM) or the selected one (Match ROM)
+            if (ctx.address_mode) {
+                build_addr_cmd(DS18B20_READ_SCRATCHPAD);
+                send_command_n(ctx.addr_cmd, DS18B20_MATCH_SLOTS);
+            } else {
+                send_command(read_cmd);
+            }
             // Transition to READ state
             ctx.current_state = 6;
         } else {
@@ -574,6 +662,18 @@ void ds18b20_poll(void) {
 }
 
 /**
+ * @brief Kick the non-blocking state machine so the next poll() starts a cycle
+ * @note The blocking search clears the timer update flag on every operation,
+ *       which would otherwise leave the state machine waiting forever for the
+ *       UIF that idles in state 0. Setting UIF here restores the original
+ *       behaviour where the first poll() after startup began a measurement.
+ */
+__STATIC_FORCEINLINE void kick_state_machine(void) {
+    T1.EGR = TIM_EGR(UG);
+    __DSB();
+}
+
+/**
  * @brief Search the 1-Wire bus and report every device ROM address
  * @param[in] sink Callback invoked once per found device with its 64-bit ROM
  *                 address (LSB first). May be NULL to only count devices.
@@ -613,7 +713,7 @@ uint8_t ds18b20_search_devices(uint8_t (*sink)(const uint8_t* rom), uint8_t max_
                 read_2bits(&id_bit, &cmp_bit);
                 if (id_bit && cmp_bit) {
                     // No device follows this path - search tree exhausted
-                    last_discrepancy = 0;
+                    kick_state_machine();
                     return found;
                 }
                 if (id_bit != cmp_bit) {
@@ -660,6 +760,8 @@ uint8_t ds18b20_search_devices(uint8_t (*sink)(const uint8_t* rom), uint8_t max_
         }
     }
 
+    // Kick the non-blocking state machine (see kick_state_machine)
+    kick_state_machine();
     return found;
 }
 

--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -622,15 +622,22 @@ uint8_t ds18b20_search_devices(uint8_t (*sink)(const uint8_t* rom), uint8_t max_
                 } else if (id_bit_number < last_discrepancy) {
                     // Follow the previously taken path
                     direction = (rom[byte_idx] & mask) ? 1u : 0u;
+                    if (direction == 0) {
+                        // Remember the last 0-branch taken at a discrepancy
+                        last_zero = id_bit_number;
+                    }
                 } else {
                     // At the discrepancy point take the '1' branch first
                     direction = (id_bit_number == last_discrepancy) ? 1u : 0u;
+                    if (direction == 0) {
+                        // Remember the last 0-branch taken at a discrepancy
+                        last_zero = id_bit_number;
+                    }
                 }
                 if (direction) {
                     rom[byte_idx] |= mask;
                 } else {
                     rom[byte_idx] &= (uint8_t)~mask;
-                    last_zero = id_bit_number;
                 }
                 write_bit(direction);
                 id_bit_number++;

--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -86,6 +86,12 @@ static DS18B20_ctx_t ctx;
 #define DS18B20_BITS_PER_BYTE 8
 /** @brief Total number of bits in DS18B20 scratchpad */
 #define DS18B20_SCRATCHPAD_BITS (DS18B20_SCRATCHPAD_LEN * DS18B20_BITS_PER_BYTE)
+/** @brief Number of bytes in a device ROM address */
+#define DS18B20_ROM_BYTES 8
+/** @brief Total number of bits in a device ROM address */
+#define DS18B20_ROM_BITS (DS18B20_ROM_BYTES * DS18B20_BITS_PER_BYTE)
+/** @brief DS18B20 Search ROM command */
+#define DS18B20_SEARCH_ROM 0xF0
 /** @brief Threshold to distinguish short/long pulses (10µs) */
 #define SHORT_PULSE_MAX 0x0A
 /** @brief Number of DMA transfers for command transmission */
@@ -155,16 +161,18 @@ __WEAK void ds18b20_complete(int16_t temp_tenths) {
 }
 
 /**
- * @brief Calculate CRC8 checksum for DS18B20 scratchpad data validation
- * @return CRC8 checksum value
+ * @brief Calculate Dallas/Maxim CRC-8 over a byte buffer
+ * @param[in] data Input buffer
+ * @param[in] len Number of bytes to process
+ * @return CRC-8 checksum value
  */
-__STATIC_FORCEINLINE uint8_t check_scratchpad_crc(void) {
+__STATIC_FORCEINLINE uint8_t crc8_calc(const uint8_t* data, uint8_t len) {
     uint8_t crc = 0;
-    // Process each byte in the scratchpad (first 8 bytes) for CRC calculation
-    for (uint8_t i = 0; i < DS18B20_CRC8_BYTES; i++) {
-        uint8_t inByte = ctx.scratchpad[i];
+    // Process each byte in the buffer
+    for (uint8_t i = 0; i < len; i++) {
+        uint8_t inByte = data[i];
         // Process each bit in the byte using Dallas/Maxim CRC8 algorithm
-        for (uint8_t b = 0; b < 8; b++) {
+        for (uint8_t b = 0; b < DS18B20_BITS_PER_BYTE; b++) {
             uint8_t mix = (crc ^ inByte) & 0x01;
             crc >>= 1;
             if (mix) crc ^= DS18B20_CRC8_POLY;
@@ -172,6 +180,14 @@ __STATIC_FORCEINLINE uint8_t check_scratchpad_crc(void) {
         }
     }
     return crc;
+}
+
+/**
+ * @brief Calculate CRC8 checksum for DS18B20 scratchpad data validation
+ * @return CRC8 checksum value
+ */
+__STATIC_FORCEINLINE uint8_t check_scratchpad_crc(void) {
+    return crc8_calc(ctx.scratchpad, DS18B20_CRC8_BYTES);
 }
 
 /**
@@ -325,6 +341,101 @@ __STATIC_FORCEINLINE void read_data(void) {
  */
 
 /**
+ * @defgroup DS18B20_Blocking_Search DS18B20 Blocking Bus Search
+ * @brief One-time, blocking helpers used by ds18b20_search_devices()
+ * @note These are the only functions in the driver that busy-wait on UIF.
+ *       They reuse the same hardware-timed 1-Wire primitives as the state
+ *       machine but wait for each operation synchronously.
+ * @{
+ */
+
+/**
+ * @brief Wait for the timer to finish its current one-shot operation
+ * @note Busy-waits on the update flag. Used only by the blocking search.
+ */
+__STATIC_FORCEINLINE void wait_timer_done(void) {
+    __DSB();
+    while (!(T1.SR & TIM_SR(UIF))) {
+    }
+    T1.SR = 0;
+}
+
+/**
+ * @brief Write one bit to the 1-Wire bus as a single hardware-timed slot
+ * @param[in] bit 1 = short low pulse (~5µs), 0 = long low pulse (~60µs)
+ * @note Blocking: waits for the slot to finish before returning.
+ */
+__STATIC_FORCEINLINE void write_bit(uint8_t bit) {
+    T1.RCR = 0; // Single slot, no repetition
+    T1.ARR = ONE_PULSE + ZERO_PULSE + GUARD_BAND; // Total bit slot time
+    T1.CCR1 = bit ? ONE_PULSE : ZERO_PULSE; // Pulse duration encodes the bit
+    // Configure channel 1 for output compare (drive bus low during the pulse)
+    T1.CCMR1 = TIM_CCMR1(OC1M_0, OC1M_1, OC1M_2);
+    T1.CCER = TIM_CCER(CC1E); // Enable output compare
+    T1.DIER = 0; // No DMA for a single bit slot
+    FORCE_UPDATE_EVENT(T1);
+    T1.CR1 = TIM_CR1(OPM, CEN); // Start timer in one-pulse mode
+    wait_timer_done();
+}
+
+/**
+ * @brief Write one byte to the 1-Wire bus, LSB first
+ * @param[in] byte Byte value to transmit
+ * @note Blocking: 8 sequential single-slot writes, waits between slots.
+ */
+__STATIC_FORCEINLINE void send_byte(uint8_t byte) {
+    for (uint8_t i = 0; i < DS18B20_BITS_PER_BYTE; i++) {
+        write_bit((byte >> i) & 0x01);
+    }
+}
+
+/**
+ * @brief Read two consecutive bits from the 1-Wire bus (Search ROM pair)
+ * @param[out] id_bit First bit read in the slot
+ * @param[out] cmp_bit Second (complement) bit read in the same slot
+ * @note Blocking: runs two read slots (RCR=1) in a single timer transaction
+ *       and decodes the captured pulse widths like read_data() does.
+ */
+__STATIC_FORCEINLINE void read_2bits(uint8_t* id_bit, uint8_t* cmp_bit) {
+    volatile uint8_t samples[2];
+    T1.RCR = 1; // Two read slots
+    T1.ARR = ONE_PULSE + ZERO_PULSE + GUARD_BAND; // Total bit slot time
+    T1.CCR1 = ONE_PULSE; // Read pulse duration (ONE_PULSE µs)
+    // Configure channel 1 for output compare (generate read pulse)
+    // Configure channel 2 for input capture (measure return pulse durations)
+    T1.CCMR1 = TIM_CCMR1(OC1M_0, OC1M_1, OC1M_2, OC1PE, CC2S_1, IC2F_0, IC2F_1, IC2F_2);
+    T1.CCER = TIM_CCER(CC1E, CC2E); // Enable both channels
+    T1.DIER = TIM_DIER(CC2DE); // Enable DMA request on capture
+    FORCE_UPDATE_EVENT(T1);
+    T1.CCR1 = 0; // Clear output compare value
+    // Configure DMA to capture pulse durations into the local buffer
+    D13.CCR = 0; // Clear DMA configuration
+    D13.CPAR = (uint32_t)&T1.CCR2; // DMA destination: capture register
+    D13.CMAR = (uint32_t)samples; // DMA source: local sample buffer
+    D13.CNDTR = 2; // Number of transfers (2 bits)
+    D13.CCR = DMA_CCR(MINC, PSIZE_0, EN); // Enable DMA with memory increment
+    T1.CR1 = TIM_CR1(OPM, CEN); // Start timer in one-pulse mode
+    wait_timer_done();
+    // Decode using the same threshold as decode_scratchpad()
+    *id_bit = (samples[0] <= SHORT_PULSE_MAX) ? 1u : 0u;
+    *cmp_bit = (samples[1] <= SHORT_PULSE_MAX) ? 1u : 0u;
+}
+
+/**
+ * @brief Perform a blocking 1-Wire reset and check for a presence pulse
+ * @return 1 if at least one device answered the reset, 0 otherwise
+ */
+__STATIC_FORCEINLINE uint8_t search_reset(void) {
+    reset_bus();
+    wait_timer_done();
+    return check_presence();
+}
+
+/**
+ * @}
+ */
+
+/**
  * @defgroup DS18B20_Public_Functions DS18B20 Public Functions
  * @{
  */
@@ -460,6 +571,89 @@ void ds18b20_poll(void) {
         ctx.current_state = 0;
         break;
     }
+}
+
+/**
+ * @brief Search the 1-Wire bus and report every device ROM address
+ * @param[in] sink Callback invoked once per found device with its 64-bit ROM
+ *                 address (LSB first). May be NULL to only count devices.
+ *                 Return non-zero from the callback to stop the search early.
+ * @param[in] max_devices Maximum number of devices to report (0 aborts)
+ * @return Number of devices found on the bus
+ * @note Blocking - intended for one-time use at startup. Implements the
+ *       standard Maxim 1-Wire Search ROM (0xF0) algorithm with the
+ *       last-discrepancy method and CRC-8 validation.
+ */
+uint8_t ds18b20_search_devices(uint8_t (*sink)(const uint8_t* rom), uint8_t max_devices) {
+    uint8_t rom[DS18B20_ROM_BYTES] = {0};
+    uint8_t found = 0;
+    uint8_t last_device = 0;
+    uint16_t last_discrepancy = 0;
+
+    if (max_devices == 0) {
+        return 0;
+    }
+
+    // Repeat the search until every device has been enumerated
+    while (!last_device && found < max_devices) {
+        if (!search_reset()) {
+            // No device answered - reset and stop the search
+            last_discrepancy = 0;
+            break;
+        }
+
+        send_byte(DS18B20_SEARCH_ROM);
+
+        uint16_t id_bit_number = 1;
+        uint16_t last_zero = 0;
+        for (uint8_t byte_idx = 0; byte_idx < DS18B20_ROM_BYTES; byte_idx++) {
+            uint8_t mask = 1;
+            for (uint8_t bit_idx = 0; bit_idx < DS18B20_BITS_PER_BYTE; bit_idx++) {
+                uint8_t id_bit, cmp_bit, direction;
+                read_2bits(&id_bit, &cmp_bit);
+                if (id_bit && cmp_bit) {
+                    // No device follows this path - search tree exhausted
+                    last_discrepancy = 0;
+                    return found;
+                }
+                if (id_bit != cmp_bit) {
+                    // Single device on this path - its bit fixes the direction
+                    direction = id_bit;
+                } else if (id_bit_number < last_discrepancy) {
+                    // Follow the previously taken path
+                    direction = (rom[byte_idx] & mask) ? 1u : 0u;
+                } else {
+                    // At the discrepancy point take the '1' branch first
+                    direction = (id_bit_number == last_discrepancy) ? 1u : 0u;
+                }
+                if (direction) {
+                    rom[byte_idx] |= mask;
+                } else {
+                    rom[byte_idx] &= (uint8_t)~mask;
+                    last_zero = id_bit_number;
+                }
+                write_bit(direction);
+                id_bit_number++;
+                mask <<= 1;
+            }
+        }
+        last_discrepancy = last_zero;
+
+        // Validate the assembled ROM address
+        if (crc8_calc(rom, DS18B20_ROM_BYTES) != 0) {
+            break;
+        }
+
+        found++;
+        if (sink && sink(rom)) {
+            break; // Callback requested an early stop
+        }
+        if (last_discrepancy == 0) {
+            last_device = 1; // This was the last device on the bus
+        }
+    }
+
+    return found;
 }
 
 /**

--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -321,7 +321,7 @@ __STATIC_FORCEINLINE void send_command_n(const uint8_t* cmd, uint16_t slots) {
     FORCE_UPDATE_EVENT(T1);
     // Configure DMA to transmit command pulse sequence
     D14.CCR = 0; // Clear DMA configuration
-    D14.CPAR = (uint32_t)&TIM1->CCR1; // DMA destination: output compare register
+    D14.CPAR = (uint32_t)&T1.CCR1; // DMA destination: output compare register
     D14.CMAR = (uint32_t)&cmd[1]; // DMA source: command data (skip first byte)
     D14.CNDTR = slots; // Number of transfers
     D14.CCR = DMA_CCR(DIR, MINC, PSIZE_0, EN); // Enable DMA with memory increment


### PR DESCRIPTION
## Summary

Implements the non-blocking Maxim Search ROM (0xF0) driver and a hardware-verified device search for multi-sensor DS18B20 buses, then refactors the driver to expose only a small high-level API.

## What's included

- **Device search (non-blocking)**: \ds18b20_search_start()\ / \ds18b20_search_poll()\ / \ds18b20_search_count()\ implement the Maxim Search ROM algorithm as a compact state machine that performs exactly one hardware-timed operation per poll call, then hands the timer back to \ds18b20_poll()\. Filters by family code (0x28) and validates the CRC.
- **Bug fixes** (both root-caused via on-target timing measurements):
  - \ds18b20_bus_read_pair()\ used a 16-bit DMA PSIZE with an 8-bit MSIZE, corrupting the captured id/cmp bit timings → fixed to \MSIZE_0\.
  - The search wrote the raw direction bit (0/1) through \ds18b20_bus_write_slots()\, which expects pulse durations → \