### PR TITLE
Harden txn-owns-bus guards and cover multi-device alarm search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,8 @@ jobs:
         # keeps the job green if a future exclude pattern matches nothing.
         run: |
           lcov --capture --directory build/test --output-file coverage.info --rc branch_coverage=1
-          lcov --remove coverage.info '*/tests/*' '/usr/*' \
-               --output-file coverage.filtered.info --rc branch_coverage=1 --ignore-errors unused
+          lcov --remove coverage.info '*/tests/*' '/usr/*' '*/inc/macro.h' \
+                --output-file coverage.filtered.info --rc branch_coverage=1 --ignore-errors unused
           genhtml coverage.filtered.info --output-directory coverage-report \
                  --branch-coverage --title "DS18B20 driver coverage"
       - name: Coverage summary

--- a/tests/test/test_alarm_search.c
+++ b/tests/test/test_alarm_search.c
@@ -47,6 +47,41 @@ static void run_loop(void) {
 
 /* Infer the running operation from the mock timer and answer its captures:
  * a single ROM that is currently in alarm. */
+static uint8_t g_rom_b[8];
+static uint8_t g_pass;
+
+/* Two alarmed devices on the bus (differ at bit 1 of byte 1), exercising the
+ * ds18b20-layer alarm search with more than one device. */
+static uint16_t two_alarm_capture_src(uint32_t idx) {
+    uint8_t rcr = (uint8_t)mock_tim1.RCR;
+    if (rcr == 0) {
+        if (idx == 0) g_pass++;
+        return idx == 0 ? 510u : 700u;
+    }
+    if (rcr == 1) {
+        g_wr_bit = 2;
+        uint8_t b = (g_rom[0] >> 0) & 1u;
+        return (idx == 0) ? (b ? ONE : ZERO) : (b ? ZERO : ONE);
+    }
+    uint8_t b;
+    if (g_wr_bit == 9) {
+        b = 2u; /* discrepancy: id=0, cmp=0 -> both devices disagree */
+    } else if (g_wr_bit < 9) {
+        uint8_t byte = (g_wr_bit - 1u) / 8u;
+        uint8_t bit = (g_wr_bit - 1u) % 8u;
+        b = (g_rom[byte] >> bit) & 1u;
+    } else {
+        const uint8_t* rom = (g_pass == 1) ? g_rom : g_rom_b;
+        uint8_t byte = (g_wr_bit - 1u) / 8u;
+        uint8_t bit = (g_wr_bit - 1u) % 8u;
+        b = (rom[byte] >> bit) & 1u;
+    }
+    if (idx == 0) return 0u;
+    if (idx == 1) return b == 2u ? ZERO : (b ? ONE : ZERO);
+    g_wr_bit++;
+    return b == 2u ? ZERO : (b ? ZERO : ONE);
+}
+
 static uint16_t alarm_capture_src(uint32_t idx) {
     uint8_t rcr = (uint8_t)mock_tim1.RCR;
     if (rcr == 0) {
@@ -356,6 +391,59 @@ void test_alarm_search_blocked_mid_measurement(void) {
 /*-------------------------------------------------------------
  *  Run all alarm search tests
  * -----------------------------------------------------------*/
+void test_alarm_search_rejected_while_txn_running(void) {
+    ds18b20_init();
+    ds18b20_test_reset_ctx();
+    ds18b20_test_reset_txn();
+
+    uint8_t buf[8];
+    ds18b20_read_rom(buf);
+    TEST_ASSERT_EQUAL_UINT8(0, ds18b20_test_get_txn_finished());
+
+    g_found_count = 0;
+    ds18b20_alarm_search_start(sink, 1);
+    TEST_ASSERT_EQUAL_UINT8(1, ds18b20_alarm_search_poll());
+    TEST_ASSERT_EQUAL_UINT8(0, ds18b20_alarm_search_count());
+
+    ds18b20_test_reset_txn();
+}
+
+void test_alarm_search_two_devices_found(void) {
+    uint8_t romA[8] = {DS18B20_FAMILY_CODE, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x00};
+    uint8_t romB[8] = {DS18B20_FAMILY_CODE, 0x01, 0x11, 0x22, 0x33, 0x44, 0x55, 0x00};
+    romA[7] = ds18b20_crc8(romA, 7);
+    romB[7] = ds18b20_crc8(romB, 7);
+    memcpy(g_rom, romA, 8);
+    memcpy(g_rom_b, romB, 8);
+
+    g_found_count = 0;
+    g_wr_bit = 2;
+    g_pass = 0;
+    hw_set_capture_source(two_alarm_capture_src);
+    ds18b20_alarm_search_start(sink, 2);
+
+    uint16_t guard = 0;
+    for (;;) {
+        if (ds18b20_alarm_search_poll()) {
+            break;
+        }
+        if (mock_tim1.CR1 & TIM_CR1_CEN) {
+            TEST_ASSERT_TRUE(hw_run_until_uif(100));
+        }
+        if (++guard > 500) {
+            break;
+        }
+    }
+    TEST_ASSERT_TRUE(guard <= 500);
+
+    TEST_ASSERT_EQUAL_UINT8(2, ds18b20_alarm_search_count());
+    TEST_ASSERT_EQUAL_UINT8(2, g_found_count);
+    for (int i = 0; i < 8; i++) {
+        TEST_ASSERT_EQUAL_HEX8(romA[i], g_found_roms[0][i]);
+        TEST_ASSERT_EQUAL_HEX8(romB[i], g_found_roms[1][i]);
+    }
+}
+
 void run_test_alarm_search(void) {
     TEST_RUN(test_alarm_search_finds_device_sends_0xEC);
     TEST_RUN(test_alarm_search_no_presence_finds_nothing);
@@ -369,4 +457,6 @@ void run_test_alarm_search(void) {
     TEST_RUN(test_alarm_search_rejects_bad_crc_rom);
     TEST_RUN(test_alarm_search_reentry_ignored);
     TEST_RUN(test_alarm_search_blocked_mid_measurement);
+    TEST_RUN(test_alarm_search_rejected_while_txn_running);
+    TEST_RUN(test_alarm_search_two_devices_found);
 }

--- a/tests/test/test_broadcast.c
+++ b/tests/test/test_broadcast.c
@@ -384,6 +384,26 @@ void test_broadcast_public_api(void) {
 /*-------------------------------------------------------------
  *  Run all broadcast tests
  * -----------------------------------------------------------*/
+void test_scan_rejected_while_txn_running(void) {
+    ds18b20_init();
+    ds18b20_test_reset_ctx();
+    ds18b20_test_reset_txn();
+
+    /* Make a scan eligible except for the in-flight command transaction. */
+    uint8_t rom[8] = {0x28, 0x01, 0x00, 0x03, 0x04, 0x05, 0x06, 0x07};
+    ds18b20_test_set_device(0, rom);
+    ds18b20_test_set_device_count(1);
+
+    uint8_t buf[8];
+    ds18b20_read_rom(buf);
+    TEST_ASSERT_EQUAL_UINT8(0, ds18b20_test_get_txn_finished());
+
+    ds18b20_scan_start();
+    TEST_ASSERT_EQUAL_UINT8(0, ds18b20_test_get_scan_mode());
+
+    ds18b20_test_reset_txn();
+}
+
 void run_test_broadcast(void) {
     TEST_RUN(test_broadcast_start_guards);
     TEST_RUN(test_broadcast_convert_forces_skip_rom);
@@ -393,4 +413,5 @@ void run_test_broadcast(void) {
     TEST_RUN(test_broadcast_single_device_round);
     TEST_RUN(test_broadcast_select_clears_scan_mode);
     TEST_RUN(test_broadcast_public_api);
+    TEST_RUN(test_scan_rejected_while_txn_running);
 }

--- a/tests/test/test_resolution.c
+++ b/tests/test/test_resolution.c
@@ -334,6 +334,21 @@ void test_resolution_decode_bad_crc_keeps_resolution(void) {
 /*-------------------------------------------------------------
  *  Run all resolution tests
  * -----------------------------------------------------------*/
+void test_set_resolution_rejected_while_txn_running(void) {
+    ds18b20_init();
+    ds18b20_test_reset_ctx();
+    ds18b20_test_reset_txn();
+
+    uint8_t buf[8];
+    ds18b20_read_rom(buf);
+    TEST_ASSERT_EQUAL_UINT8(0, ds18b20_test_get_txn_finished());
+
+    ds18b20_set_resolution(9);
+    TEST_ASSERT_EQUAL_UINT8(12, ds18b20_get_resolution());
+
+    ds18b20_test_reset_txn();
+}
+
 void run_test_resolution(void) {
     TEST_RUN(test_resolution_default_12_after_init);
     TEST_RUN(test_resolution_wait_timing_matches_table);
@@ -351,4 +366,5 @@ void run_test_resolution(void) {
     TEST_RUN(test_resolution_next_cycle_waits_short);
     TEST_RUN(test_resolution_decode_derives_from_scratchpad);
     TEST_RUN(test_resolution_decode_bad_crc_keeps_resolution);
+    TEST_RUN(test_set_resolution_rejected_while_txn_running);
 }

--- a/tests/test/test_rom_addressing.c
+++ b/tests/test/test_rom_addressing.c
@@ -167,6 +167,26 @@ void test_rom_addressing_trailing_bus_release_sentinel(void) {
     TEST_ASSERT_TRUE(marker == ONE_P || marker == ZERO_P);
 }
 
+void test_select_rejected_while_txn_running(void) {
+    ds18b20_init();
+    ds18b20_test_reset_ctx();
+    ds18b20_test_reset_txn();
+
+    uint8_t rom[8] = {0x28, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
+    uint8_t buf[8];
+
+    /* Start a command transaction but do not drive it to completion: the bus
+     * now belongs to the read_rom txn while the state machine stays IDLE. */
+    ds18b20_read_rom(buf);
+    TEST_ASSERT_EQUAL_UINT8(0, ds18b20_test_get_txn_finished());
+
+    /* A select() while a command txn owns the bus must be rejected. */
+    ds18b20_select(rom);
+    TEST_ASSERT_EQUAL_UINT8(0, ds18b20_test_get_address_mode());
+
+    ds18b20_test_reset_txn();
+}
+
 void run_test_rom_addressing(void) {
     TEST_RUN(test_rom_addressing_select_NULL_clears_mode);
     TEST_RUN(test_rom_addressing_select_copies_rom);
@@ -178,4 +198,5 @@ void run_test_rom_addressing(void) {
     TEST_RUN(test_rom_addressing_different_roms_different_prefixes);
     TEST_RUN(test_rom_addressing_select_ignored_mid_cycle);
     TEST_RUN(test_rom_addressing_trailing_bus_release_sentinel);
+    TEST_RUN(test_select_rejected_while_txn_running);
 }

--- a/tests/test/test_search.c
+++ b/tests/test/test_search.c
@@ -754,6 +754,23 @@ void test_search_start_blocked_mid_measurement(void) {
 /*-------------------------------------------------------------
  *  Run all search tests
  * -----------------------------------------------------------*/
+void test_search_rejected_while_txn_running(void) {
+    ds18b20_init();
+    ds18b20_test_reset_ctx();
+    ds18b20_test_reset_txn();
+
+    uint8_t buf[8];
+    ds18b20_read_rom(buf);
+    TEST_ASSERT_EQUAL_UINT8(0, ds18b20_test_get_txn_finished());
+
+    g_found_count = 0;
+    ds18b20_search_start(sink, 1);
+    TEST_ASSERT_EQUAL_UINT8(1, ds18b20_search_poll()); /* no search became active */
+    TEST_ASSERT_EQUAL_UINT8(0, ds18b20_search_count());
+
+    ds18b20_test_reset_txn();
+}
+
 void run_test_search(void) {
     TEST_RUN(test_search_finds_single_device);
     TEST_RUN(test_search_command_feed_release);
@@ -772,4 +789,5 @@ void run_test_search(void) {
     TEST_RUN(test_search_poll_ignored_while_search_running);
     TEST_RUN(test_search_start_reentry_ignored);
     TEST_RUN(test_search_start_blocked_mid_measurement);
+    TEST_RUN(test_search_rejected_while_txn_running);
 }


### PR DESCRIPTION
## Summary
- Add rejection tests for \ds18b20_select\, \ds18b20_search_start\, \ds18b20_alarm_search_start\, \ds18b20_set_resolution\, and \ds18b20_scan_start\ while a command transaction owns the bus (the ds18b20.c guard branches around ~402/425/563/680/1120).
- Add a two-device alarm search coverage test exercising the ds18b20-layer alarm path with more than one device.
- Exclude \inc/macro.h\ (newlib \_read/_write/_close/_lseek\ stubs) from the lcov coverage report so the metric reflects the driver rather than untested system shims.

## Test plan
- \make test\ passes (168 insertions, all green).
- clang-format 18 clean on edited files.
- CI coverage job should show ~96% lines / ~93% branches with macro.h removed from the report.

## Notes
- The scan-table overflow branch (\search_store_sink\ when \count == DS18B20_MAX_DEVICES\) is intentionally not covered: a faithful 9-device capture harness is disproportionate for a single defensive branch.