### PR TITLE
Tighten ds18b20_select() guard; allow re-select from scan callback

### DIFF
--- a/inc/ds18b20.h
+++ b/inc/ds18b20.h
@@ -500,10 +500,12 @@ void ds18b20_poll(void);
  *       responds. Pass NULL to keep the legacy single-sensor Skip ROM
  *       behaviour. To measure a specific device, pass its ROM address
  *       (e.g., from a bus search) to ds18b20_select().
- * @note The selection is applied only between measurement cycles (driver
- *       IDLE); calls made mid-cycle are ignored. It is safe to re-select from
- *       inside the ds18b20_complete() callback, which the driver invokes
- *       already in the IDLE state.
+ * @note The selection is applied only when no bus transaction is in flight
+ *       (driver IDLE, or the per-device DS18B20_ST_DECODE state inside a scan
+ *       callback); calls made mid-cycle are ignored. It is safe to re-select
+ *       from inside the ds18b20_complete() callback: in single-device mode the
+ *       driver invokes it at IDLE, and in scan mode at DECODE, where a non-NULL
+ *       rom switches the driver out of scan mode to address that single device.
  */
 void ds18b20_select(const uint8_t* rom);
 

--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -652,6 +652,11 @@ uint8_t ds18b20_get_resolution(void) { return ctx.resolution; }
  */
 static void scan_finish_or_next(void) {
     if (!ctx.scan_mode) {
+        /* Single-device mode, or a select() issued from the scan callback that
+         * switched us out of scan mode: return the state machine to IDLE so the
+         * next poll starts a fresh (single-device) cycle instead of re-entering
+         * the DECODE state it was left in. */
+        ctx.current_state = DS18B20_ST_IDLE;
         start_cycle_pause();
         return;
     }
@@ -1113,12 +1118,28 @@ void ds18b20_init(void) {
  *       already in the IDLE state).
  */
 void ds18b20_select(const uint8_t* rom) {
-    if (ctx.current_state != DS18B20_ST_IDLE) {
+    /* Select is safe only when no bus transaction is in flight. In scan mode
+     * the per-device ds18b20_complete() callback runs at DS18B20_ST_DECODE
+     * (after the read, nothing pending), so a select() there is accepted too
+     * and lets the application switch to single-device addressing from inside
+     * the callback. Every other state means a transaction is mid-flight. */
+    const uint8_t selectable =
+        (uint8_t)(ctx.current_state == DS18B20_ST_IDLE ||
+                  (ctx.current_state == DS18B20_ST_DECODE && ctx.scan_mode));
+    if (!selectable) {
         // Mid-cycle call - reject to keep the in-flight transaction intact.
         return;
     }
     if (!txn_ctx.finished) {
         // A command transaction is running - reject to keep its addressing.
+        return;
+    }
+    if (!res_ctx.finished) {
+        // A resolution change is running - reject to keep its addressing.
+        return;
+    }
+    if (onewire_search_active()) {
+        // The device search owns the timer - reject to keep its addressing.
         return;
     }
     // Explicit single-device addressing: leave simultaneous-conversion mode.

--- a/tests/test/test_rom_addressing.c
+++ b/tests/test/test_rom_addressing.c
@@ -187,6 +187,62 @@ void test_select_rejected_while_txn_running(void) {
     ds18b20_test_reset_txn();
 }
 
+void test_select_rejected_during_search(void) {
+    ds18b20_init();
+    ds18b20_test_reset_ctx();
+    ds18b20_test_reset_txn();
+    ds18b20_test_reset_search();
+
+    /* A search owns the timer: select() must be rejected even at IDLE. */
+    ds18b20_search_start(0, 1);
+    TEST_ASSERT_EQUAL_UINT8(0, ds18b20_search_poll()); /* search still running */
+
+    uint8_t rom[8] = {0x28, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
+    ds18b20_select(rom);
+    TEST_ASSERT_EQUAL_UINT8(0, ds18b20_test_get_address_mode());
+    ds18b20_test_reset_search();
+}
+
+void test_select_rejected_during_resolution_change(void) {
+    ds18b20_init();
+    ds18b20_test_reset_ctx();
+    ds18b20_test_reset_txn();
+    ds18b20_test_reset_search();
+
+    /* A resolution change owns the timer: select() must be rejected. */
+    ds18b20_set_resolution(9);
+
+    uint8_t rom[8] = {0x28, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
+    ds18b20_select(rom);
+    TEST_ASSERT_EQUAL_UINT8(0, ds18b20_test_get_address_mode());
+    ds18b20_test_reset_resolution();
+    ds18b20_test_reset_txn();
+}
+
+void test_select_accepted_from_scan_callback(void) {
+    ds18b20_init();
+    ds18b20_test_reset_ctx();
+    ds18b20_test_reset_txn();
+    ds18b20_test_reset_search();
+
+    /* Mimic the per-device scan callback context: state is DECODE while a scan
+     * is in progress. A select() there must be accepted and must switch the
+     * driver out of scan mode to address a single device. */
+    ds18b20_test_set_scan_mode(1);
+    ds18b20_test_set_state(DS18B20_ST_DECODE);
+
+    uint8_t rom[8] = {0x28, 0x0A, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
+    ds18b20_select(rom);
+    TEST_ASSERT_EQUAL_UINT8(1, ds18b20_test_get_address_mode());
+    TEST_ASSERT_EQUAL_UINT8(0, ds18b20_test_get_scan_mode());
+
+    uint8_t got[8];
+    ds18b20_test_get_selected_rom(got);
+    for (uint8_t i = 0; i < 8; i++) {
+        TEST_ASSERT_EQUAL_HEX8(rom[i], got[i]);
+    }
+}
+
 void run_test_rom_addressing(void) {
     TEST_RUN(test_rom_addressing_select_NULL_clears_mode);
     TEST_RUN(test_rom_addressing_select_copies_rom);
@@ -199,4 +255,7 @@ void run_test_rom_addressing(void) {
     TEST_RUN(test_rom_addressing_select_ignored_mid_cycle);
     TEST_RUN(test_rom_addressing_trailing_bus_release_sentinel);
     TEST_RUN(test_select_rejected_while_txn_running);
+    TEST_RUN(test_select_rejected_during_search);
+    TEST_RUN(test_select_rejected_during_resolution_change);
+    TEST_RUN(test_select_accepted_from_scan_callback);
 }


### PR DESCRIPTION
## Summary
Resolves two points from the recent code review.

### Point 2 — ds18b20_select() guard was narrower than \	xn_can_start()\
The old guard rejected only on a non-IDLE state and a running command transaction, but ignored an in-progress resolution change and an active device search. Added the missing \!res_ctx.finished\ and \!onewire_search_active()\ checks so \select()\ is consistently rejected whenever the bus is owned by another operation.

### Point 1 — re-select from the scan callback was silently rejected
The header promised \ds18b20_select()\ is safe from inside \ds18b20_complete()\, but in scan mode the callback runs at \DS18B20_ST_DECODE\ (not IDLE), so the call was dropped. \select()\ is now accepted at \(DS18B20_ST_DECODE && scan_mode)\; a non-NULL rom switches the driver out of scan mode to address a single device from the scan callback.

Also fixed \scan_finish_or_next()\ to return the state machine to IDLE when \select()\ switched it out of scan mode mid-round (otherwise it would re-enter DECODE and re-report the last device), and updated the header doc to describe the real IDLE / scan-DECODE contract.

## Test plan
- 3 new unit tests in \	est_rom_addressing.c\: \select()\ rejected during an active search, during a resolution change, and accepted (switching out of scan mode) from the scan-callback DECODE state.
- \make test\ passes (all green), clang-format 18 clean.

## Next step
Hardware verification of the scan \->\ single-device switch via \ds18b20_select()\ from the scan callback before merging into \main\.