### PR TITLE
fix(ds18b20): reject ds18b20_select() from scan callback, correct docs

### DIFF
--- a/inc/ds18b20.h
+++ b/inc/ds18b20.h
@@ -501,11 +501,12 @@ void ds18b20_poll(void);
  *       behaviour. To measure a specific device, pass its ROM address
  *       (e.g., from a bus search) to ds18b20_select().
  * @note The selection is applied only when no bus transaction is in flight
- *       (driver IDLE, or the per-device DS18B20_ST_DECODE state inside a scan
- *       callback); calls made mid-cycle are ignored. It is safe to re-select
- *       from inside the ds18b20_complete() callback: in single-device mode the
- *       driver invokes it at IDLE, and in scan mode at DECODE, where a non-NULL
- *       rom switches the driver out of scan mode to address that single device.
+ *       (driver IDLE). Calls made mid-cycle are ignored, including from the
+ *       per-device scan callback, which the driver invokes at
+ *       DS18B20_ST_DECODE mid-round: a select() there is rejected and the scan
+ *       round continues. To switch out of scan mode, call ds18b20_select()
+ *       from ds18b20_complete() in single-device mode (the callback runs at
+ *       IDLE) or between measurement rounds (at IDLE).
  */
 void ds18b20_select(const uint8_t* rom);
 

--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -652,11 +652,6 @@ uint8_t ds18b20_get_resolution(void) { return ctx.resolution; }
  */
 static void scan_finish_or_next(void) {
     if (!ctx.scan_mode) {
-        /* Single-device mode, or a select() issued from the scan callback that
-         * switched us out of scan mode: return the state machine to IDLE so the
-         * next poll starts a fresh (single-device) cycle instead of re-entering
-         * the DECODE state it was left in. */
-        ctx.current_state = DS18B20_ST_IDLE;
         start_cycle_pause();
         return;
     }
@@ -1111,23 +1106,23 @@ void ds18b20_init(void) {
  *       legacy single-sensor Skip ROM behaviour. The address should come from
  *       the non-blocking device search (ds18b20_search_*).
  * @note The selection is applied only between measurement cycles (driver
- *       IDLE). Calls made while a cycle is running are ignored: applying them
- *       mid-cycle would overwrite ctx.addr_cmd while the DMA is still feeding
- *       it, corrupting the in-flight bus transaction. Re-call once the cycle
- *       finished (e.g., from ds18b20_complete(), which the driver invokes
- *       already in the IDLE state).
+ *       IDLE). Calls made while a cycle is running are ignored, including from
+ *       the per-device scan callback (which the driver invokes at
+ *       DS18B20_ST_DECODE mid-round): a select() there is rejected and the
+ *       scan round continues. Applying a select mid-cycle would overwrite
+ *       ctx.addr_cmd while the DMA is still feeding it, corrupting the
+ *       in-flight bus transaction. Re-call at IDLE (e.g. from
+ *       ds18b20_complete() in single-device mode, or between rounds) to switch
+ *       addressing.
  */
 void ds18b20_select(const uint8_t* rom) {
-    /* Select is safe only when no bus transaction is in flight. In scan mode
-     * the per-device ds18b20_complete() callback runs at DS18B20_ST_DECODE
-     * (after the read, nothing pending), so a select() there is accepted too
-     * and lets the application switch to single-device addressing from inside
-     * the callback. Every other state means a transaction is mid-flight. */
-    const uint8_t selectable =
-        (uint8_t)(ctx.current_state == DS18B20_ST_IDLE ||
-                  (ctx.current_state == DS18B20_ST_DECODE && ctx.scan_mode));
-    if (!selectable) {
-        // Mid-cycle call - reject to keep the in-flight transaction intact.
+    /* Select is accepted only when no bus transaction is in flight, i.e. at
+     * driver IDLE. The per-device scan callback runs at DS18B20_ST_DECODE
+     * mid-round: a select() there is rejected so it cannot interrupt the
+     * in-progress scan. To leave scan mode, call select() between measurement
+     * rounds (at IDLE) or from the single-device ds18b20_complete() callback
+     * (which runs at IDLE). */
+    if (ctx.current_state != DS18B20_ST_IDLE) {
         return;
     }
     if (!txn_ctx.finished) {
@@ -1267,10 +1262,11 @@ void ds18b20_poll(void) {
         // Turn off LED to indicate measurement complete
         ds18b20_busy(0);
 
-        // Return to IDLE before the callback so a re-selection from inside
-        // ds18b20_complete() is accepted (ds18b20_select() only acts at IDLE).
-        // Scan mode keeps its own per-device addressing, so it stays in DECODE
-        // and reports every device before returning to IDLE at the round end.
+        // In single-device mode the callback runs at IDLE, so a re-selection
+        // from inside ds18b20_complete() is accepted there. Scan mode keeps its
+        // own per-device addressing and stays in DECODE: a select() from the
+        // scan callback is rejected, and it reports every device before
+        // returning to IDLE at the round end.
         if (!ctx.scan_mode) {
             ctx.current_state = DS18B20_ST_IDLE;
         }

--- a/tests/test/test_rom_addressing.c
+++ b/tests/test/test_rom_addressing.c
@@ -219,28 +219,22 @@ void test_select_rejected_during_resolution_change(void) {
     ds18b20_test_reset_txn();
 }
 
-void test_select_accepted_from_scan_callback(void) {
+void test_select_rejected_from_scan_callback(void) {
     ds18b20_init();
     ds18b20_test_reset_ctx();
     ds18b20_test_reset_txn();
     ds18b20_test_reset_search();
 
     /* Mimic the per-device scan callback context: state is DECODE while a scan
-     * is in progress. A select() there must be accepted and must switch the
-     * driver out of scan mode to address a single device. */
+     * is in progress. A select() there must be rejected and the scan round must
+     * continue (scan mode unchanged). */
     ds18b20_test_set_scan_mode(1);
     ds18b20_test_set_state(DS18B20_ST_DECODE);
 
     uint8_t rom[8] = {0x28, 0x0A, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
     ds18b20_select(rom);
-    TEST_ASSERT_EQUAL_UINT8(1, ds18b20_test_get_address_mode());
-    TEST_ASSERT_EQUAL_UINT8(0, ds18b20_test_get_scan_mode());
-
-    uint8_t got[8];
-    ds18b20_test_get_selected_rom(got);
-    for (uint8_t i = 0; i < 8; i++) {
-        TEST_ASSERT_EQUAL_HEX8(rom[i], got[i]);
-    }
+    TEST_ASSERT_EQUAL_UINT8(0, ds18b20_test_get_address_mode());
+    TEST_ASSERT_EQUAL_UINT8(1, ds18b20_test_get_scan_mode());
 }
 
 void run_test_rom_addressing(void) {
@@ -257,5 +251,5 @@ void run_test_rom_addressing(void) {
     TEST_RUN(test_select_rejected_while_txn_running);
     TEST_RUN(test_select_rejected_during_search);
     TEST_RUN(test_select_rejected_during_resolution_change);
-    TEST_RUN(test_select_accepted_from_scan_callback);
+    TEST_RUN(test_select_rejected_from_scan_callback);
 }


### PR DESCRIPTION
## Summary

Reverts the code portion of the scan-callback re-select that was added in PR #7, per the decided alternative **B**: keep \ds18b20_select()\ accepted only at driver IDLE and document that honestly.

- \ds18b20_select()\ no longer accepts the call from the per-device scan callback (which runs at \DS18B20_ST_DECODE\ mid-round). Such a call is now rejected so it cannot interrupt an in-progress scan; the round continues as before.
- Removed the \!scan_mode\ early-exit branch in \scan_finish_or_next()\ that the PR #7 change had added.
- Corrected the documentation in \inc/ds18b20.h\ and the \ds18b20.c\ comment: re-select is applied only when no bus transaction is in flight (driver IDLE) — from the single-device \ds18b20_complete()\ callback or between measurement rounds. Switching out of scan mode is done at IDLE, not from the scan callback.
- Flipped the unit test \	est_select_accepted_from_scan_callback\ to \	est_select_rejected_from_scan_callback\ (asserts scan mode and addressing are unchanged).

## Kept from PR #7

The txn-owns-bus guards in \ds18b20_select()\ (\!txn_ctx.finished\, \!res_ctx.finished\, \!onewire_search_active()\) remain — they close a genuine corruption path (the original guard only checked \current_state == IDLE\, which is also true while a search / resolution change / command transaction owns the timer).

## Verification

- Host unit tests: PASS (0 failures).
- clang-format: clean.
- ARM build of demo3: clean.
- Hardware (STM32F103C8T6, 8 sensors, ST-LINK V2 via COM5): scan still reports all 8 devices with stable readings; no regression from the revert.