### PR TITLE
refactor(onewire): deduplicate bit-decode via onewire_decode_pulses helper

### DIFF
--- a/inc/onewire.h
+++ b/inc/onewire.h
@@ -130,6 +130,27 @@ void onewire_write_then_read(uint8_t bit);
 void onewire_read_data(volatile uint8_t* dst, uint8_t bytes);
 
 /**
+ * @brief Decode a single captured pulse duration into a 1-Wire bit
+ * @param[in] dur Pulse duration in microseconds
+ * @return 1 if the pulse is short (bit value '1'), 0 if long (bit value '0')
+ * @note A pulse duration `<= ONEWIRE_SHORT_PULSE_MAX` is the short ('1') slot.
+ */
+static inline uint8_t onewire_bit_from_pulse(uint16_t dur) {
+    return (dur <= ONEWIRE_SHORT_PULSE_MAX) ? 1u : 0u;
+}
+
+/**
+ * @brief Decode captured pulse durations into data bytes (LSB-first bits)
+ * @param[out] dst Decoded bytes
+ * @param[in] pulse Captured per-bit pulse durations (one entry per bit)
+ * @param[in] nbytes Number of bytes to decode (pulse must hold nbytes × 8 entries)
+ * @note Each bit is recovered with onewire_bit_from_pulse(); bit 0 maps to the
+ *       LSB of its byte. Recovers scratchpad / register bytes from the 1-Wire
+ *       read capture.
+ */
+void onewire_decode_pulses(uint8_t* dst, const volatile uint8_t* pulse, uint8_t nbytes);
+
+/**
  * @brief Encode a byte into write-pulse durations
  * @param[out] out Output buffer (8 entries)
  * @param[in] byte Byte value to encode

--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -25,8 +25,6 @@
 #define DS18B20_CRC8_BYTES 8
 /** @brief Total number of bits in DS18B20 scratchpad */
 #define DS18B20_SCRATCHPAD_BITS (DS18B20_SCRATCHPAD_LEN * DS18B20_BITS_PER_BYTE)
-/** @brief Pulse threshold separating short ('1') from long ('0') slots (from the 1-Wire layer) */
-#define SHORT_PULSE_MAX ONEWIRE_SHORT_PULSE_MAX
 /** @brief Total slots for Match ROM + 8-byte ROM + command */
 #define DS18B20_MATCH_SLOTS ((DS18B20_ROM_BYTES + 2) * DS18B20_BITS_PER_BYTE)
 /** @brief Slots for the invariant Match ROM + 8-byte ROM prefix (built on select) */
@@ -238,14 +236,9 @@ __STATIC_FORCEINLINE uint8_t check_scratchpad_crc(void) {
  *       then writes once per byte. Relies on union aliasing invariant — see DS18B20_ctx_t.
  */
 __STATIC_FORCEINLINE void decode_scratchpad(void) {
-    for (unsigned byte = 0; byte < DS18B20_SCRATCHPAD_LEN; ++byte) {
-        const unsigned base = byte * DS18B20_BITS_PER_BYTE;
-        unsigned value = 0;
-        for (unsigned bit = 0; bit < DS18B20_BITS_PER_BYTE; ++bit) {
-            value |= (unsigned)(ctx.pulse[base + bit] <= SHORT_PULSE_MAX) << bit;
-        }
-        ctx.scratchpad[byte] = (uint8_t)value;
-    }
+    /* Captured pulse durations (volatile, written by the read DMA) carry one
+     * bit each; onewire_decode_pulses() recovers the scratchpad bytes. */
+    onewire_decode_pulses(ctx.scratchpad, ctx.pulse, DS18B20_SCRATCHPAD_LEN);
 }
 
 /**
@@ -795,16 +788,7 @@ __STATIC_FORCEINLINE void txn_build_pulses(void) {
  *       the union invariant of decode_scratchpad() does not apply here.
  */
 __STATIC_FORCEINLINE void txn_decode_read(void) {
-    for (uint8_t byte = 0; byte < txn_ctx.read_bytes; byte++) {
-        const uint8_t base = (uint8_t)(byte * DS18B20_BITS_PER_BYTE);
-        uint8_t value = 0;
-        for (uint8_t bit = 0; bit < DS18B20_BITS_PER_BYTE; bit++) {
-            value |= (ctx.pulse[base + bit] <= SHORT_PULSE_MAX)
-                         ? (uint8_t)(1u << bit)
-                         : 0u;
-        }
-        txn_ctx.raw[byte] = value;
-    }
+    onewire_decode_pulses(txn_ctx.raw, ctx.pulse, txn_ctx.read_bytes);
 }
 
 /**

--- a/src/onewire.c
+++ b/src/onewire.c
@@ -283,8 +283,8 @@ void onewire_read_pair(volatile uint16_t* edge_out) {
 }
 
 void onewire_pair_bits(const volatile uint16_t* edge, uint8_t* id_bit, uint8_t* cmp_bit) {
-    *id_bit = (edge[0] <= ONEWIRE_SHORT_PULSE_MAX) ? 1u : 0u;
-    *cmp_bit = (edge[1] <= ONEWIRE_SHORT_PULSE_MAX) ? 1u : 0u;
+    *id_bit = onewire_bit_from_pulse(edge[0]);
+    *cmp_bit = onewire_bit_from_pulse(edge[1]);
 }
 
 void onewire_write_then_read(uint8_t bit) {
@@ -335,6 +335,16 @@ void onewire_read_data(volatile uint8_t* dst, uint8_t bytes) {
     T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND;
     T1.CCR1 = ONEWIRE_ONE_PULSE;
     arm_capture((volatile void*)dst, bits, 8);
+}
+
+void onewire_decode_pulses(uint8_t* dst, const volatile uint8_t* pulse, uint8_t nbytes) {
+    for (uint8_t byte = 0; byte < nbytes; byte++) {
+        uint8_t value = 0;
+        for (uint8_t bit = 0; bit < ONEWIRE_BITS_PER_BYTE; bit++) {
+            value |= (uint8_t)(onewire_bit_from_pulse(pulse[byte * ONEWIRE_BITS_PER_BYTE + bit]) << bit);
+        }
+        dst[byte] = value;
+    }
 }
 
 void onewire_encode_byte(uint8_t* out, uint8_t byte) {
@@ -516,8 +526,8 @@ uint8_t onewire_search_poll(void) {
         // captured the id/cmp pair of the current bit into search_edge3.
         search_ctx.id_bit_number++;
         onewire_search_advance_bit(
-            (search_edge3[1] <= ONEWIRE_SHORT_PULSE_MAX) ? 1u : 0u,
-            (search_edge3[2] <= ONEWIRE_SHORT_PULSE_MAX) ? 1u : 0u);
+            onewire_bit_from_pulse(search_edge3[1]),
+            onewire_bit_from_pulse(search_edge3[2]));
         break;
 
     case ONEWIRE_SEARCH_WRITE_DIR:

--- a/tests/test/test_pulse_encoding.c
+++ b/tests/test/test_pulse_encoding.c
@@ -7,6 +7,7 @@
 
 #include "ds18b20.h"
 #include "ds18b20_test_access.h"
+#include "onewire.h"
 #include "unity.h"
 
 #define ONE_P 5u
@@ -91,6 +92,58 @@ void test_pulse_encoding_single_bit_positions(void) {
     }
 }
 
+void test_onewire_bit_from_pulse_short_is_one(void) {
+    TEST_ASSERT_EQUAL_UINT8(1, onewire_bit_from_pulse(0));
+    TEST_ASSERT_EQUAL_UINT8(1, onewire_bit_from_pulse(ONEWIRE_SHORT_PULSE_MAX));
+    TEST_ASSERT_EQUAL_UINT8(1, onewire_bit_from_pulse(5));
+}
+
+void test_onewire_bit_from_pulse_long_is_zero(void) {
+    TEST_ASSERT_EQUAL_UINT8(0, onewire_bit_from_pulse(ONEWIRE_SHORT_PULSE_MAX + 1));
+    TEST_ASSERT_EQUAL_UINT8(0, onewire_bit_from_pulse(60));
+    TEST_ASSERT_EQUAL_UINT8(0, onewire_bit_from_pulse(0xFFFF));
+}
+
+void test_onewire_decode_pulses_all_short_is_0xFF(void) {
+    uint8_t pulse[8];
+    for (int i = 0; i < 8; i++)
+        pulse[i] = (uint8_t)ONEWIRE_SHORT_PULSE_MAX;
+    uint8_t dst[1];
+    onewire_decode_pulses(dst, pulse, 1);
+    TEST_ASSERT_EQUAL_UINT8(0xFF, dst[0]);
+}
+
+void test_onewire_decode_pulses_all_long_is_0x00(void) {
+    uint8_t pulse[8];
+    for (int i = 0; i < 8; i++)
+        pulse[i] = 60;
+    uint8_t dst[1];
+    onewire_decode_pulses(dst, pulse, 1);
+    TEST_ASSERT_EQUAL_UINT8(0x00, dst[0]);
+}
+
+void test_onewire_decode_pulses_pattern(void) {
+    uint8_t pulse[8];
+    for (int i = 0; i < 8; i++) {
+        pulse[i] = (uint8_t)(((0x55u >> i) & 1u) ? ONEWIRE_SHORT_PULSE_MAX : 60u);
+    }
+    uint8_t dst[1];
+    onewire_decode_pulses(dst, pulse, 1);
+    TEST_ASSERT_EQUAL_UINT8(0x55, dst[0]);
+}
+
+void test_onewire_decode_pulses_two_bytes(void) {
+    uint8_t pulse[16];
+    for (int i = 0; i < 16; i++) {
+        uint8_t byte = (i < 8) ? 0x55u : 0xAAu;
+        pulse[i] = (uint8_t)(((byte >> (i % 8)) & 1u) ? ONEWIRE_SHORT_PULSE_MAX : 60u);
+    }
+    uint8_t dst[2];
+    onewire_decode_pulses(dst, pulse, 2);
+    TEST_ASSERT_EQUAL_UINT8(0x55, dst[0]);
+    TEST_ASSERT_EQUAL_UINT8(0xAA, dst[1]);
+}
+
 void run_test_pulse_encoding(void) {
     TEST_RUN(test_pulse_encoding_zero_byte_all_zero_pulse);
     TEST_RUN(test_pulse_encoding_0xFF_all_one_pulse);
@@ -101,4 +154,10 @@ void run_test_pulse_encoding(void) {
     TEST_RUN(test_pulse_encoding_output_length_always_8);
     TEST_RUN(test_pulse_encoding_only_valid_pulse_values);
     TEST_RUN(test_pulse_encoding_single_bit_positions);
+    TEST_RUN(test_onewire_bit_from_pulse_short_is_one);
+    TEST_RUN(test_onewire_bit_from_pulse_long_is_zero);
+    TEST_RUN(test_onewire_decode_pulses_all_short_is_0xFF);
+    TEST_RUN(test_onewire_decode_pulses_all_long_is_0x00);
+    TEST_RUN(test_onewire_decode_pulses_pattern);
+    TEST_RUN(test_onewire_decode_pulses_two_bytes);
 }


### PR DESCRIPTION
Resolves review point 5.

Extracts the short/long pulse threshold comparison (was open-coded in four places: decode_scratchpad, txn_decode_read, onewire_pair_bits, ONEWIRE_SEARCH_WRITE_READ) into onewire_bit_from_pulse() and onewire_decode_pulses() in the 1-Wire layer. All four sites now call the shared helpers.

- host unit tests added (boundaries + byte patterns) for both helpers
- clang-format clean, ARM build clean (text 3616, no regression)
- hardware-verified on STM32F103C8T6: 8 DS18B20 sensors still report stable temps over COM5