### PR TITLE
doc(ds18b20): document ctx.resolution desync after recall_eeprom

### DIFF
--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -1010,6 +1010,13 @@ uint8_t ds18b20_copy_scratchpad_poll(void) { return txn_poll(); }
  * @note Loads the last EEPROM copy (TH/TL/CFG) into the volatile scratchpad.
  *       The driver waits the datasheet t_RECALL hold-off (10ms) before
  *       finishing.
+ * @note After recall, the scratchpad holds the EEPROM-stored configuration
+ *       (TH/TL/CFG, including the conversion-resolution bits). The driver's
+ *       tracked ctx.resolution is NOT updated by this call: Recall is a
+ *       write-only command with no data returned. If the EEPROM resolution
+ *       may differ from ctx.resolution, follow this with
+ *       ds18b20_read_scratchpad() / ds18b20_read_scratchpad_poll() to
+ *       resynchronise ctx.resolution before the next conversion.
  */
 void ds18b20_recall_eeprom(void) {
     txn_start(DS18B20_RECALL_EEPROM, 0, 0, 0, 0, DS18B20_EEPROM_WAIT_US, 0);
@@ -1018,8 +1025,21 @@ void ds18b20_recall_eeprom(void) {
 /**
  * @brief Advance the non-blocking Recall EEPROM transaction
  * @return 1 when finished (successfully or aborted), 0 while running
+ * @warning ctx.resolution is NOT updated on success. Recall is a write-only
+ *          command; the device does not return the restored config. To keep
+ *          ctx.resolution in sync with a possibly-different EEPROM resolution,
+ *          call ds18b20_read_scratchpad_poll() after this returns 1 and
+ *          ds18b20_last_command_ok() is set.
  */
-uint8_t ds18b20_recall_eeprom_poll(void) { return txn_poll(); }
+uint8_t ds18b20_recall_eeprom_poll(void) {
+    if (!txn_poll()) {
+        return 0;
+    }
+    /* Nothing to decode: Recall returns no data, so there is no scratchpad
+     * frame to parse here. The caller is responsible for resynchronising
+     * ctx.resolution via ds18b20_read_scratchpad_poll() if needed. */
+    return 1;
+}
 
 /**
  * @brief Read the power-supply state of the DS18B20

--- a/tests/test/test_eeprom.c
+++ b/tests/test/test_eeprom.c
@@ -226,6 +226,10 @@ void test_eeprom_persistence_e2e(void) {
     ds18b20_recall_eeprom();
     drive_txn(ds18b20_recall_eeprom_poll);
     TEST_ASSERT_EQUAL_UINT8(1, ds18b20_last_command_ok());
+    /* NOTE: ds18b20_recall_eeprom_poll does NOT update ctx.resolution.
+     * It is a write-only command. A follow-up scratchpad read (step 4) is
+     * the documented way to resynchronise ctx.resolution if the EEPROM
+     * config differs from the tracked one. */
 
     /* 4. Read the scratchpad back; feed the expected TH/TL/CFG so the driver
      *    decodes a valid frame and we confirm the data path returns them. */


### PR DESCRIPTION
Resolves review comment on ds18b20_recall_eeprom_poll.

Recall EEPROM is a write-only command and does not return the restored config byte, so the driver's tracked ctx.resolution is left unchanged after a successful recall. If the EEPROM resolution differs from ctx.resolution, the local context desynchronises (the next conversion wait in wait_conversion() would be wrong).

Option B (as discussed): keep recall as a single transaction and document the limitation rather than chaining a hidden scratchpad read.

Changes:
- ds18b20_recall_eeprom_poll: make txn_ctx.ok status explicit; add @warning that ctx.resolution is not updated
- ds18b20_recall_eeprom: add @note pointing callers to ds18b20_read_scratchpad_poll() to resync
- test_eeprom.c: note in test_eeprom_persistence_e2e why the follow-up scratchpad read is the documented sync path

Verified: make test (0 failures), clang-format clean, ARM build clean (demo4). demo4 already chains recall -> scratchpad read (STEP_RECALL -> STEP_SCRATCH_AFTER_RECALL).