### PR TITLE
fix(ds18b20/onewire): align resolution slot count with build and clear stale presence edge

### DIFF
--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -212,6 +212,7 @@ typedef struct {
     uint8_t pending_res; /**< Resolution (bits) to apply */
     uint8_t applied; /**< 1 once the config write completed (resolution actually changed) */
     uint8_t finished; /**< 1 once the operation has completed (or aborted) */
+    uint8_t slots; /**< Bit slots in the built config write (incl. prefix and payload) */
     uint8_t pulses[DS18B20_RES_SLOTS_MAX + 1]; /**< Pulse buffer for the config write (+ trailing 0 for hardware bus release) */
 } res_ctx_t;
 
@@ -539,7 +540,8 @@ __STATIC_FORCEINLINE void build_res_pulses(uint8_t res) {
     onewire_encode_byte(p, DS18B20_RES_TL);
     p += DS18B20_BITS_PER_BYTE;
     onewire_encode_byte(p, res_config_byte(res));
-    res_ctx.pulses[use_match ? DS18B20_RES_SLOTS_MAX : DS18B20_RES_SLOTS_MIN] = 0;
+    res_ctx.slots = use_match ? DS18B20_RES_SLOTS_MAX : DS18B20_RES_SLOTS_MIN;
+    res_ctx.pulses[res_ctx.slots] = 0;
 }
 
 /**
@@ -613,9 +615,7 @@ uint8_t ds18b20_set_resolution_poll(void) {
             res_ctx.phase = DS18B20_RES_DONE;
             break;
         }
-        onewire_write_slots(res_ctx.pulses,
-                            ctx.address_mode ? DS18B20_RES_SLOTS_MAX
-                                             : DS18B20_RES_SLOTS_MIN);
+        onewire_write_slots(res_ctx.pulses, res_ctx.slots);
         res_ctx.phase = DS18B20_RES_WRITE;
         break;
 

--- a/src/onewire.c
+++ b/src/onewire.c
@@ -215,6 +215,12 @@ void onewire_reset(volatile uint16_t* edge_out) {
     T1.RCR = 0;
     T1.ARR = RESET_TIMEOUT;
     T1.CCR1 = RESET_PULSE_DURATION;
+    /* Clear the capture buffer: only edge[0] (master release) is always written
+     * by the DMA, so a no-presence reset would otherwise leave a stale edge[1]
+     * from a previous presence reset and onewire_present() would report a false
+     * device. Zeroing makes a single-capture reset report "no device". */
+    edge_out[0] = 0;
+    edge_out[1] = 0;
     arm_capture((volatile void*)edge_out, CAPTURE_BUF_SIZE, 16);
 }
 

--- a/tests/test/test_presence.c
+++ b/tests/test/test_presence.c
@@ -79,6 +79,18 @@ void test_presence_reset_max_presence_min(void) {
     assert_presence(RESET_MAX, PRES_MIN, 1);
 }
 
+/* Regression for the stale edge[1] bug: a no-presence reset captures only
+ * edge[0], so a stale presence timestamp left in edge[1] from a previous reset
+ * would make onewire_present() report a false device. onewire_reset() must
+ * clear the capture buffer before arming. */
+void test_presence_reset_clears_stale_edge(void) {
+    ds18b20_test_set_edge(0, 510); /* stale master-release timestamp */
+    ds18b20_test_set_edge(1, 700); /* stale presence timestamp */
+    test_bus_reset();
+    TEST_ASSERT_EQUAL_UINT16(0, ds18b20_test_get_edge(0));
+    TEST_ASSERT_EQUAL_UINT16(0, ds18b20_test_get_edge(1));
+}
+
 void test_capture_16bit_config(void) {
     uint16_t dst[2];
     ds18b20_test_arm_capture((volatile void*)dst, 2, 16);
@@ -116,6 +128,7 @@ void run_test_presence(void) {
     TEST_RUN(test_presence_very_large_values_absent);
     TEST_RUN(test_presence_reset_min_presence_max);
     TEST_RUN(test_presence_reset_max_presence_min);
+    TEST_RUN(test_presence_reset_clears_stale_edge);
     TEST_RUN(test_capture_16bit_config);
     TEST_RUN(test_capture_8bit_config);
 }

--- a/tests/test/test_resolution.c
+++ b/tests/test/test_resolution.c
@@ -182,6 +182,27 @@ void test_resolution_match_rom_feed_release(void) {
     TEST_ASSERT_FALSE(mock_tim1.CR1 & TIM_CR1_CEN);
 }
 
+/* Regression for the build/poll slot-count mismatch: when a resolution change
+ * runs in scan mode while a single device is still selected (address_mode == 1),
+ * the config write must broadcast (Skip ROM) and send exactly 40 slots. The poll
+ * used to send DS18B20_RES_SLOTS_MAX (104) because it only checked
+ * ctx.address_mode, leaking stale buffer contents beyond the built write. */
+void test_resolution_scan_mode_broadcasts_skip_rom(void) {
+    ds18b20_init();
+    uint8_t rom[DS18B20_ROM_BYTES] = {0x28, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
+    ds18b20_select(rom);            /* address_mode = 1 */
+    ds18b20_test_set_scan_mode(1);  /* scan mode; address_mode stays 1 */
+    hw_set_capture_source(res_capture_present);
+    drive_res_change(9);
+    TEST_ASSERT_EQUAL_UINT8(9, ds18b20_get_resolution());
+
+    /* Only the 40-slot Skip ROM broadcast is sent, not the 104-slot Match ROM. */
+    const hw_ccr1_feed_log_t* log = hw_ccr1_feed_log();
+    TEST_ASSERT_EQUAL_UINT8(40, log->count);
+    TEST_ASSERT_EQUAL_UINT16(0, log->values[39]);
+    TEST_ASSERT_EQUAL_UINT8(0, ds18b20_test_get_res_pulse(40)); /* trailing at MIN */
+}
+
 /*-------------------------------------------------------------
  *  4. Guards: range, state, search ownership, re-entry
  * -----------------------------------------------------------*/
@@ -357,6 +378,7 @@ void run_test_resolution(void) {
     TEST_RUN(test_resolution_change_all_four_values);
     TEST_RUN(test_resolution_skip_rom_feed_release);
     TEST_RUN(test_resolution_match_rom_feed_release);
+    TEST_RUN(test_resolution_scan_mode_broadcasts_skip_rom);
     TEST_RUN(test_resolution_invalid_values_ignored);
     TEST_RUN(test_resolution_blocked_mid_measurement);
     TEST_RUN(test_resolution_blocked_during_search);


### PR DESCRIPTION
## Summary

- **Resolution change in scan mode sent the wrong number of slots.** ds18b20_set_resolution_poll (RES_RESET) transmitted DS18B20_RES_SLOTS_MAX whenever ctx.address_mode was set, but uild_res_pulses uses ctx.address_mode && !ctx.scan_mode (Skip ROM broadcast in scan mode). When a resolution change ran in scan mode while a device was still selected, the poll sent 104 slots over a 40-slot Skip-ROM build, leaking stale es_ctx.pulses[40..103] onto the bus (potential corrupted config write). Fixed by storing the built slot count in es_ctx.slots and reusing it in the poll — mirroring 	xn_ctx.slots, so build and send can no longer diverge.

- **Stale presence edge on no-presence reset.** onewire_reset did not clear its capture buffer; a no-presence reset (only edge[0] captured) could inherit a stale edge[1] from a prior presence reset and make onewire_present() report a false device. Fixed by zeroing the buffer before arming capture.

## Verification
- make test: 221 pass (added 2 regression tests).
- clang-format --dry-run --Werror: clean.
- make APP=demo3 / make APP=demo4: build OK.

## Regression tests
- 	est_resolution_scan_mode_broadcasts_skip_rom: scan-mode resolution change with a selected device sends exactly 40 Skip-ROM slots (would have been 104).
- 	est_presence_reset_clears_stale_edge: onewire_reset zeroes a stale edge buffer.

Note: hardware flash verification could not be run this session (ST-LINK did not connect); logic is covered by the unit tests above.