### PR TITLE
fix(release): drop duplicated loop tail and show make output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,13 +82,11 @@ jobs:
             [ "$target" != "-" ] && flags="$flags OW_TARGET=$target"
             [ "$hsi" != "-" ] && flags="$flags HSI_8MHZ=1"
             echo "::group::build $out (APP=$app OW_TARGET=$target HSI_8MHZ=$hsi)"
-            make clean >/dev/null
-            make APP=$app $flags >/dev/null
+            make clean
+            make APP=$app $flags
             for ext in elf hex bin; do
               cp "build/ds18b20_$app.$ext" "dist/$out.$ext"
             done
-            echo "::endgroup::"
-          done
             echo "::endgroup::"
           done
 


### PR DESCRIPTION
The matrix step carried a stray `echo ::endgroup::` + `done` pair left over from editing: bash executed the whole 16-row loop and only then died on the trailing tokens. Also drop the `>/dev/null` on make so build errors are visible in CI logs.

Matrix script verified locally: exit=0, 48 artifacts staged.