### PR TITLE
feat(port-f1): unify TIM1 channels with the F0 backend, bus PA8 -> PA10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** STM32F1 backend moved to the same TIM1 channel scheme as
+  STM32F0: the 1-Wire bus now runs on **PA10** (previously PA8) as TIM1_CH3
+  PWM output with CH4 indirect capture (IC4 <- TI3); the slot-end marker sits
+  on a plain CC2 compare feeding CCR3 through DMA1 channel 2, while captures
+  drain CCR4 through DMA1 channel 4. Re-wire DQ from PA8 to PA10 when
+  upgrading. Register-level timer logic is now identical across both
+  backends; only the prescaler, GPIO pin configuration and two fixed DMA
+  request channels differ.
+
 ## [1.4.1] - 2026-08-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ A bare-metal, register-level driver for the DS18B20 temperature sensor. This dri
 
 The core (`src/onewire.c` + `src/ds18b20.c`) is MCU-independent and rides on a small port interface (`inc/ow_port.h`); per-MCU backends are header-only implementations under `port/`. Two backends ship today:
 
-- `port/stm32f1/ow_port_f1.h` — STM32F103C8T6 (Blue Pill): bus on PA8, TIM1 CH1 output / CH2 capture, DMA1 channels 3/6.
+- `port/stm32f1/ow_port_f1.h` — STM32F103C8T6 (Blue Pill): bus on PA10, TIM1 CH3 output / CH4 capture, DMA1 channels 2/4.
 - `port/stm32f0/ow_port_f0.h` — STM32F030x6 (e.g. TSSOP20 STM32F030F4P6): bus on PA10, TIM1 CH3 output / CH4 capture, DMA1 channels 3/4.
 
 ## Features
 
 - Pure Bare-Metal: Direct register manipulation, no HAL or LL libraries.
-- Dual-MCU Backend: One MCU-independent core over a `ow_port_*` port interface; header-only backends for STM32F1 (PA8) and STM32F0 (PA10). Select at build time with `make OW_TARGET=f0`.
+- Dual-MCU Backend: One MCU-independent core over a `ow_port_*` port interface; header-only backends for STM32F1 and STM32F0, both on the shared CH3/CH4 scheme. Select at build time with `make OW_TARGET=f0`.
 - Zero Interrupts: Does not use any NVIC interrupts. Fully polled operation.
 - RTOS-Ready: the strict 1-Wire bit timing is generated entirely by TIM1+DMA, so ds18b20_poll() can be called at any rate from an RTOS task without corrupting the bus. The driver is fully polled and interrupt-free, but is not thread-safe by itself — see RTOS Integration.
 - Hardware Automation: Uses TIM1 Output Compare and Input Capture with DMA to automate waveform generation and data capture.
@@ -78,7 +78,7 @@ The core (`src/onewire.c` + `src/ds18b20.c`) is MCU-independent and rides on a s
 │   ├── ow_port.h           # 1-Wire port layer interface (+ backend select)
 │   └── macro.h             # STM32 register access macros (F1 backend)
 ├── port/                   # Per-MCU backends for the ow_port_* interface
-│   ├── stm32f1/            # STM32F1: TIM1 + DMA1 + PA8 (header-only static inline)
+│   ├── stm32f1/            # STM32F1: TIM1 + DMA1 + PA10 (header-only static inline)
 │   │   └── ow_port_f1.h    # Register-level ow_port_* implementation for STM32F1
 │   └── stm32f0/            # STM32F0: TIM1 + DMA1 + PA10 (header-only static inline)
 │       └── ow_port_f0.h    # Register-level ow_port_* implementation for STM32F0
@@ -159,7 +159,7 @@ Notes:
 ### STM32F103C8T6 (Blue Pill)
 
 The following captures were taken on real hardware: STM32F103C8T6 (Blue Pill),
-8 × DS18B20 on one 1-Wire bus (PA8), flashed via ST-Link, USART1 TX at
+8 × DS18B20 on one 1-Wire bus (PA10), flashed via ST-Link, USART1 TX at
 115200 8N1 read through a CP2102 USB-UART adapter. The shared 1-Wire layer
 found all 8 sensors, and every measurement round reported all of them — no
 missing devices, no CRC failures.
@@ -215,11 +215,11 @@ again carried 8 × DS18B20; all rounds complete with valid CRCs and no errors:
 
 | STM32F103 Pin | Function     | DS18B20 Pin |
 |---------------|--------------|-------------|
-| PA8           | 1-Wire Data  | DQ (Data)   |
+| PA10          | 1-Wire Data  | DQ (Data)   |
 | 3.3V          | Power        | VDD         |
 | GND           | Ground       | GND         |
 
-Note: A 4.7kΩ pull-up resistor is required between the PA8 and 3.3V lines.
+Note: A 4.7kΩ pull-up resistor is required between the PA10 and 3.3V lines.
 
 #### Debug UART (optional)
 
@@ -393,7 +393,7 @@ channel/DMA wiring. 221 tests per backend cover:
 -   Non-blocking alarm search (Alarm Search ROM, 0xEC command feed, scan-table
     isolation)
 -   Non-blocking resolution change (`ds18b20_set_resolution_*`): exact wait
-    timings for 9/10/11/12 bit, Skip ROM and Match ROM config writes, CCR1-feed
+    timings for 9/10/11/12 bit, Skip ROM and Match ROM config writes, CCR3-feed
     bus release, ownership guards, presence-abort and scratchpad auto-derivation
 -   Non-blocking command transactions (`ds18b20_read_rom`,
     `ds18b20_set_alarm_thresholds`, `ds18b20_read_scratchpad`,
@@ -426,8 +426,8 @@ channel/DMA wiring. 221 tests per backend cover:
     (Cortex-M0) with `OW_TARGET=f0`.
 
 -   **Target Selection:** `make OW_TARGET=f0` builds for the STM32F0 backend
-    (bus on PA10, 48MHz default clock, `STM32F030X6_FLASH.ld`). The default
-    target is STM32F103 (bus on PA8).
+    (48MHz default clock, `STM32F030X6_FLASH.ld`). The default
+    target is STM32F103 (bus on PA10 for both).
 
 -   **HSI 8MHz Build:** By default the firmware runs on HSE 8MHz + PLL
     ×9 = 72MHz. Pass `HSI_8MHZ=1` to use the internal RC oscillator
@@ -492,8 +492,8 @@ protocol on embedded systems:
 ### Trade-offs
 
 **Cost.** This driver consumes dedicated hardware resources — TIM1 and two DMA1
-channels (CH3 for input capture, CH4 for the CCR1 feed) — that cannot be used
-for other purposes. The 1-Wire data line itself occupies one GPIO (PA8 / PA10), but any approach
+channels (CH4 for input capture, CH2 for the CCR3 feed) — that cannot be used
+for other purposes. The 1-Wire data line itself occupies one GPIO (PA10), but any approach
 needs a GPIO pin for the bus, so that is not an extra cost. Bit-banging
 approaches, by contrast, need only that one pin and no DMA, making them more
 portable across MCUs with limited peripherals.
@@ -513,7 +513,7 @@ This driver uses an advanced technique that combines multiple hardware features:
 
 1. Timer-Driven Sequences: TIM1 is configured in One-Pulse Mode (OPM). Each state machine step configures the timer for a specific operation (reset, write byte, read byte, wait) and starts it.
 2. DMA for Data Transfer: DMA is used in two key ways:
-   - Transmit (DMA1_Channel6): Feeds a pre-calculated sequence of Compare Register (CCR) values to TIM1->CCR1 to automatically generate the precise waveform for writing commands or bits.
+   - Transmit (DMA1_Channel2): Feeds a pre-calculated sequence of Compare Register (CCR) values to TIM1->CCR3 to automatically generate the precise waveform for writing commands or bits.
    - Capture (DMA1_Channel3): Automatically stores values from the TIM1->CCR2 capture register into memory to record pulse timings during read operations or presence detection.
 3. Update Event as Completion Signal: The core polling mechanism checks the Timer Update Flag (TIM1->SR UIF). This flag is set when the timer completes its one-pulse countdown, signaling that the autonomous hardware operation (e.g., sending a reset pulse, waiting 750ms) is finished.
 4. True Zero-ISR Overhead: The ds18b20_poll() function checks this flag. When set, it clears the flag and advances the state machine to the next step. This makes the entire driver event-driven by hardware completion signals without using interrupts.
@@ -558,8 +558,8 @@ complete `onewire_*` surface.
 
 ### Hardware Resources Used
 
-- TIM1 & Channels 1, 2, 3: The core timer resources.
-  - CH1 (PWM Mode 2, Output Compare): Configured in PWM Mode 2, driving PA8 as the 1-Wire output on an active-low bus.
+- TIM1 & Channels 2, 3, 4: The core timer resources.
+  - CH3 (PWM Mode 2, Output Compare): Configured in PWM Mode 2, driving PA10 as the 1-Wire output on an active-low bus.
      - Each 1-Wire bit time slot is implemented as a single PWM period
        with a low (active) portion encoding the bit:
        - Short low (~5µs) → logical '1'
@@ -568,21 +568,22 @@ complete `onewire_*` surface.
        The +5µs guard band prevents overlap between consecutive slots
        due to bus rise time and DMA latency.
     - Reset (~480µs) is generated as an extended low period (active-low) within a ~960µs slot.
-  - CH2 (Input Capture, Indirect mode): Shares the same PA8 pin internally. Used to capture presence pulses and read-slot timings after CH1 releases the bus to idle-high; DMA transfers CCR2 capture values to memory.
-  - CH3: Used as a DMA trigger, feeding CCR1 duty cycles (for CH1 output) and facilitating capture operations.
+  - CH4 (Input Capture, Indirect mode): Shares the same PA10 pin internally. Used to capture presence pulses and read-slot timings after CH3 releases the bus to idle-high; DMA transfers CCR4 capture values to memory.
+  - CH2: End-of-slot marker (a plain compare at ONE+ZERO µs); its DMA request feeds CCR3 duty cycles for the CH3 output.
 - RCR (Repetition Counter Register): Key to the state machine operation. Instead of generating an Update Event on every period, RCR controls how many timer repetitions occur before UIF is set.
   - Example: RCR=15 → the timer generates 16 PWM slots (bits) via DMA, then asserts UIF once at the end, signaling software to proceed.
   - This allows grouping a full command (two bytes), the entire 72-bit read, or long delays into single hardware-driven transactions, freeing the CPU until completion.
-- DMA1_Channel3: Peripheral-to-memory transfers from TIM1->CCR2 (captured timings).
-- DMA1_Channel6: Memory-to-peripheral transfers to TIM1->CCR1 (PWM duty cycles).
-- GPIO Pin: PA8 configured in alternate function open-drain; CH1 output and CH2 capture are multiplexed onto this single pin.
+- DMA1_Channel4: Peripheral-to-memory transfers from TIM1->CCR4 (captured timings).
+- DMA1_Channel2: Memory-to-peripheral transfers to TIM1->CCR3 (PWM duty cycles).
+- GPIO Pin: PA10 configured in alternate function open-drain; CH3 output and CH4 capture are multiplexed onto this single pin.
 
-On the STM32F0 backend the same roles map to different channels (PA8 is not
-bonded out on small F030 packages): CH3 (PWM output) + CH4 (indirect capture
-on TI3, the same pin) drive **PA10**; the slot-end marker moves to a plain
-CH2 compare whose DMA request feeds CCR3 through **DMA1_Channel3**, while
-captures drain CCR4 through **DMA1_Channel4** (fixed request map — the F0
-DMA has no CSELR mux).
+The STM32F0 backend uses exactly the same channel roles on the same bus pin:
+CH3 (PWM output) + CH4 (indirect capture on TI3, the same pin) drive
+**PA10**; the slot-end marker sits on a plain CH2 compare. Only the two DMA
+channel numbers differ, forced by each family's fixed request map (no CSELR
+mux): the marker request rides **DMA1_Channel2** on STM32F1 vs
+**DMA1_Channel3** on STM32F0, while captures drain through **DMA1_Channel4**
+on both.
 
 ### State Machine Flow (hardware-timed; polled on UIF)
 
@@ -595,13 +596,13 @@ Kickstart behavior
 
 - START (state 1)
   - LED on. Run reset_bus():
-    - CH1 issues active-low reset pulse (~480µs within ~960µs slot).
-    - CH2 (indirect input) captures presence timing into ctx.edge[0..1] via DMA from CCR2.
+    - CH3 issues active-low reset pulse (~480µs within ~960µs slot).
+    - CH4 (indirect input) captures presence timing into ctx.edge[0..1] via DMA from CCR4.
   - Set state=2.
 
 - CONVERT (state 2)
   - On UIF, check_presence() with ctx.edge[].
-    - If present: send convert command via CH1+DMA. With no selected device,
+    - If present: send convert command via CH3+DMA. With no selected device,
       this is "Skip ROM 0xCC + Convert T 0x44" (16 slots, RCR=15). With a
       device selected via ds18b20_select(), it is "Match ROM 0x55 + 8-byte ROM
       + Convert T 0x44" (80 slots, RCR=79). Set state=3.
@@ -617,14 +618,14 @@ Kickstart behavior
 
 - REQUEST (state 5)
   - On UIF, check_presence().
-    - If present: send read command via CH1+DMA. With no selected device,
+    - If present: send read command via CH3+DMA. With no selected device,
       this is "Skip ROM 0xCC + Read Scratchpad 0xBE" (16 slots). With a device
       selected, it is "Match ROM 0x55 + 8-byte ROM + Read Scratchpad 0xBE"
       (80 slots). Set state=6.
     - Else: report NO_SENSOR; start 5s pause; set state=0.
 
 - READ (state 6)
-  - On UIF: read_data() schedules 72 slots (RCR=71; ARR=70µs). CH1 emits ~5µs active-low kick at each slot start and then releases; CH2 captures sensor pulse timing; DMA fills ctx.pulse[72]. Set state=7.
+  - On UIF: read_data() schedules 72 slots (RCR=71; ARR=70µs). CH3 emits ~5µs active-low kick at each slot start and then releases; CH4 captures sensor pulse timing; DMA fills ctx.pulse[72]. Set state=7.
 
 - DECODE (state 7)
   - On UIF: decode_scratchpad() from ctx.pulse[] into ctx.scratchpad[], LED off; verify CRC; report temperature or CRC_FAIL; start 5s pause; set state=0.
@@ -666,10 +667,10 @@ Practical consequences for RTOS use:
 
 1. A delayed poll is safe **because the line is released to HIGH in hardware**,
    not by software. Every bus operation now ends with the line idle-HIGH
-   automatically: the CCR1-fed writes (`send_command_n`, the merged search op)
+   automatically: the CCR3-fed writes (`send_command_n`, the merged search op)
    append a trailing 0 to the DMA feed, and the direct-write/capture operations
    (reset, read, single-slot write) use an OC1PE preload of 0 — both applied at
-   the instant the one-pulse timer stops. There is no software `T1.CCR1 = 0`
+   the instant the one-pulse timer stops. There is no software `T1.CCR3 = 0`
    anywhere; the bus cannot be left LOW by a stale compare value, no matter how
    long the RTOS delays the next poll.
 2. The usable scheduling latency budget is ~480 µs of LOW, not a tight
@@ -1068,7 +1069,7 @@ Slot formula: `ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND
    - Fix:
      - Check all wiring connections.
      - Ensure a 4.7kΩ pull-up resistor is between the 1-Wire data line
-       (PA8 on STM32F103 / PA10 on STM32F030) and 3.3V.
+       (PA10 on both supported targets) and 3.3V.
      - Verify stable power is supplied to the DS18B20 sensor.
      - Keep data lines short to minimize noise and capacitance.
 
@@ -1088,7 +1089,7 @@ Slot formula: `ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND
 - Check the Update Flag: Read `TIM1->SR`. If the driver seems idle,
   a set UIF bit indicates a completed operation waiting to be processed
   by `ds18b20_poll()`.
-- Inspect the GPIO: Use an oscilloscope on the data pin (PA8 / PA10) to verify the 1-Wire
+- Inspect the GPIO: Use an oscilloscope on the data pin (PA10) to verify the 1-Wire
   waveforms. Look for:
   - A clean ~480µs reset pulse (MCU pulls low, then releases).
   - A presence pulse ~60-240µs after the reset pulse (sensor pulls low).

--- a/port/stm32f1/ow_port_f1.h
+++ b/port/stm32f1/ow_port_f1.h
@@ -1,18 +1,23 @@
 /**
  * @file ow_port_f1.h
- * @brief STM32F1 backend: TIM1 (advanced) + DMA1 (channels 3/6) + PA8
+ * @brief STM32F1 backend: TIM1 (advanced) + DMA1 (channels 2/4) + PA10
  *
  * Header-only static inline implementation of the ow_port_* interface for the
- * STM32F103. The 1-Wire bus runs on PA8 (TIM1_CH1 PWM output in open-drain
- * alternate function); CH2 captures in indirect mode on the same pin and DMA1
- * channel 3 moves CCR2 captures to memory, while channel 3 feeds CCR1 from a
- * precomputed pulse buffer on the CC3 compare event (DMA1 channel 6). TIM1
- * runs in one-pulse mode (OPM) with the repetition counter (RCR) batching N
- * slots into a single update event (UIF).
+ * STM32F103. The 1-Wire bus runs on PA10 (TIM1_CH3 PWM output in open-drain
+ * alternate function, default AFIO mapping); CH4 captures in indirect mode on
+ * the same pin (CC4S routes IC4 to TI3) and its DMA request (CC4DE) moves CCR4
+ * captures to memory, while the end-of-slot marker on channel 2 — a plain
+ * compare at ONE+ZERO µs whose pin is unused (PA9 belongs to USART1 TX) —
+ * feeds CCR3 from a precomputed pulse buffer through its own DMA request
+ * (CC2DE). TIM1 runs in one-pulse mode (OPM) with the repetition counter
+ * (RCR) batching N slots into a single update event (UIF).
  *
- * The CCR1 feed uses channel 3 (CC3DE) instead of channel 4 so the feed logic
- * is identical across the STM32F1 (DMA1 channel 6) and STM32F0 (DMA1 channel
- * 5, the only TIM1 channel with a DMA request that can reload CCR1) backends.
+ * The channel roles are identical to the STM32F0 backend (see ow_port_f0.h);
+ * only the prescaler, the GPIO pin configuration and two DMA channel numbers
+ * differ. The fixed DMA request routing of this family (no DMA_CSELR mux,
+ * RM0008 table 78) assigns TIM1_CC2 to channel 2 and TIM1_CH4 to channel 4;
+ * USART1_TX shares channel 4's request line but the driver's UART output
+ * runs without DMA.
  */
 
 #ifndef OW_PORT_F1_H
@@ -29,17 +34,24 @@
 #define OW_PORT_TIM_PRESCALER 71u /* 72MHz / 72 = 1MHz -> 1µs/tick */
 #endif
 
-/* @brief CH2 input capture filter (IC2F), chosen to keep the filter latency
+/* @brief CH4 input capture filter (IC4F), chosen to keep the filter latency
  *       clock-independent in µs. At 72MHz fDTS/4 with N=8 samples adds
  *       ~0.44µs; the same setting at 8MHz HSI would sample at 2MHz and add
  *       ~4µs, pushing '1' slot captures from ~8µs to 11-12µs — past
  *       ONEWIRE_SHORT_PULSE_MAX. On the slow clock use fCK_INT with N=4
- *       (~0.5µs latency) so captures stay in the '1' window. */
+ *       (~0.5µs latency) so captures stay in the '1' window. Mirrors
+ *       ow_port_f0.h. */
 #if defined(HSI_8MHZ)
-#define OW_PORT_IC2F_ARGS IC2F_1 /* fCK_INT, N=4 -> ~0.5µs @8MHz */
+#define OW_PORT_IC4F_ARGS IC4F_1 /* fCK_INT, N=4 -> ~0.5µs @8MHz */
 #else
-#define OW_PORT_IC2F_ARGS IC2F_0, IC2F_1, IC2F_2 /* fDTS/4, N=8 -> ~0.44µs @72MHz */
+#define OW_PORT_IC4F_ARGS IC4F_0, IC4F_1, IC4F_2 /* fDTS/4, N=8 -> ~0.44µs @72MHz */
 #endif
+
+/* @brief DMA channel assignment (fixed request map, RM0008 table 78):
+ *       channel 2 carries the CC2 slot-end marker request and feeds CCR3,
+ *       channel 4 carries the CC4 capture request and drains CCR4. */
+#define OW_PORT_DMA_FEED D12
+#define OW_PORT_DMA_CAPTURE D14
 
 /* @brief DMA channel control bits for 16-bit capture: MINC | PSIZE_0 | EN */
 #define OW_PORT_DMA_CCR_CAPTURE (DMA_CCR_MINC | DMA_CCR_PSIZE_0 | DMA_CCR_EN)
@@ -66,7 +78,7 @@ __STATIC_FORCEINLINE void ow_port_update_event(void) {
 }
 
 /**
- * @brief Enable clocks, configure the timer prescaler and PA8 open-drain AF
+ * @brief Enable clocks, configure the timer prescaler and PA10 open-drain AF
  */
 __STATIC_FORCEINLINE void ow_port_init(void) {
     RC.APB2ENR |= RCC_APB2ENR(IOPAEN, TIM1EN);
@@ -74,7 +86,8 @@ __STATIC_FORCEINLINE void ow_port_init(void) {
     T1.PSC = OW_PORT_TIM_PRESCALER;
     ow_port_kick(); /* kickstart: first poll advances immediately */
     T1.BDTR = TIM_BDTR(MOE);
-    PA.CRH |= GPIO_CRH(CNF8_0, CNF8_1, MODE8_1);
+    /* PA10: alternate function open-drain, 2MHz (TIM1_CH3, default map) */
+    PA.CRH |= GPIO_CRH(CNF10_0, CNF10_1, MODE10_1);
 }
 
 /**
@@ -85,9 +98,9 @@ __STATIC_FORCEINLINE uint8_t ow_port_bus_done(void) {
     if (T1.SR & TIM_SR(UIF)) {
         /* No software bus release needed: every operation returns the line to
          * idle HIGH in hardware. DMA-fed writes (ow_port_feed,
-         * ow_port_write_then_read) append a trailing 0 to the CCR1 feed, and
+         * ow_port_write_then_read) append a trailing 0 to the CCR3 feed, and
          * the direct-write/capture operations (reset, read, single slot) use
-         * an OC1PE preload of 0 — both applied exactly when the one-pulse
+         * an OC3PE preload of 0 — both applied exactly when the one-pulse
          * timer stops. */
         T1.SR = 0;
         return 1u;
@@ -102,16 +115,16 @@ __STATIC_FORCEINLINE uint8_t ow_port_bus_done(void) {
  * @param[in] width DMA transfer width: 8 for 8-bit, 16 for 16-bit
  */
 __STATIC_FORCEINLINE void ow_port_capture(volatile void* dst, uint16_t count, uint16_t width) {
-    T1.CCMR1 = TIM_CCMR1(OC1M_0, OC1M_1, OC1M_2, OC1PE, CC2S_1, OW_PORT_IC2F_ARGS);
-    T1.CCER = TIM_CCER(CC1E, CC2E);
-    T1.DIER = TIM_DIER(CC2DE);
+    T1.CCMR2 = TIM_CCMR2(OC3M_0, OC3M_1, OC3M_2, OC3PE, CC4S_1, OW_PORT_IC4F_ARGS);
+    T1.CCER = TIM_CCER(CC3E, CC4E);
+    T1.DIER = TIM_DIER(CC4DE);
     ow_port_update_event();
-    T1.CCR1 = 0;
-    D13.CCR = 0;
-    D13.CPAR = (uint32_t)&T1.CCR2;
-    D13.CMAR = (uint32_t)dst;
-    D13.CNDTR = count;
-    D13.CCR = OW_PORT_DMA_CCR_CAPTURE | ((width == 16) ? DMA_CCR_MSIZE_0 : 0);
+    T1.CCR3 = 0;
+    OW_PORT_DMA_CAPTURE.CCR = 0;
+    OW_PORT_DMA_CAPTURE.CPAR = (uint32_t)&T1.CCR4;
+    OW_PORT_DMA_CAPTURE.CMAR = (uint32_t)dst;
+    OW_PORT_DMA_CAPTURE.CNDTR = count;
+    OW_PORT_DMA_CAPTURE.CCR = OW_PORT_DMA_CCR_CAPTURE | ((width == 16) ? DMA_CCR_MSIZE_0 : 0);
     T1.CR1 = TIM_CR1(OPM, CEN);
 }
 
@@ -120,25 +133,25 @@ __STATIC_FORCEINLINE void ow_port_capture(volatile void* dst, uint16_t count, ui
  * @param[in] cmd Pointer to command sequence in pulse duration format
  * @param[in] slots Number of bit slots (bits) to transmit
  * @note The buffer must hold `slots + 1` entries and the entry at index
- *       `slots` must be 0: the final CC3-triggered DMA transfer feeds that
- *       trailing 0 into CCR1 during the last slot, so the one-pulse timer
+ *       `slots` must be 0: the final CC2-triggered DMA transfer feeds that
+ *       trailing 0 into CCR3 during the last slot, so the one-pulse timer
  *       stops with the line already released to idle HIGH (hardware bus
- *       release — no software CCR1 write needed afterwards).
+ *       release — no software CCR3 write needed afterwards).
  */
 __STATIC_FORCEINLINE void ow_port_feed(const uint8_t* cmd, uint16_t slots) {
     T1.RCR = slots - 1;
     T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND;
-    T1.CCR1 = cmd[0];
-    T1.CCR3 = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE;
-    T1.CCMR1 = TIM_CCMR1(OC1M_0, OC1M_1, OC1M_2);
-    T1.CCER = TIM_CCER(CC1E);
-    T1.DIER = TIM_DIER(CC3DE);
+    T1.CCR3 = cmd[0];
+    T1.CCR2 = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE;
+    T1.CCMR2 = TIM_CCMR2(OC3M_0, OC3M_1, OC3M_2);
+    T1.CCER = TIM_CCER(CC3E);
+    T1.DIER = TIM_DIER(CC2DE);
     ow_port_update_event();
-    D16.CCR = 0;
-    D16.CPAR = (uint32_t)&T1.CCR1;
-    D16.CMAR = (uint32_t)&cmd[1];
-    D16.CNDTR = slots; /* Feed slots 2..N, then the trailing 0 (bus release) */
-    D16.CCR = DMA_CCR(DIR, MINC, PSIZE_0, EN);
+    OW_PORT_DMA_FEED.CCR = 0;
+    OW_PORT_DMA_FEED.CPAR = (uint32_t)&T1.CCR3;
+    OW_PORT_DMA_FEED.CMAR = (uint32_t)&cmd[1];
+    OW_PORT_DMA_FEED.CNDTR = slots; /* Feed slots 2..N, then the trailing 0 (bus release) */
+    OW_PORT_DMA_FEED.CCR = DMA_CCR(DIR, MINC, PSIZE_0, EN);
     T1.CR1 = TIM_CR1(OPM, CEN);
 }
 
@@ -161,7 +174,7 @@ __STATIC_FORCEINLINE void ow_port_start_timer(uint16_t arr, uint8_t rcr) {
 __STATIC_FORCEINLINE void ow_port_reset(volatile uint16_t* edge_out) {
     T1.RCR = 0;
     T1.ARR = OW_PORT_RESET_TIMEOUT;
-    T1.CCR1 = OW_PORT_RESET_PULSE_DURATION;
+    T1.CCR3 = OW_PORT_RESET_PULSE_DURATION;
     /* Clear the capture buffer: only edge[0] (master release) is always written
      * by the DMA, so a no-presence reset would otherwise leave a stale edge[1]
      * from a previous presence reset and onewire_present() would report a false
@@ -182,14 +195,14 @@ __STATIC_FORCEINLINE void ow_port_write_slots(const uint8_t* pulses, uint16_t sl
         /* Single slot: no DMA needed, avoids a zero-length DMA transaction */
         T1.RCR = 0; /* Single slot, no repetition */
         T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND; /* Total bit slot time */
-        T1.CCR1 = pulses[0]; /* Pulse duration encodes the bit */
-        /* OC1PE plus a preload zero release the bus at the terminal update
+        T1.CCR3 = pulses[0]; /* Pulse duration encodes the bit */
+        /* OC3PE plus a preload zero release the bus at the terminal update
          * event, exactly when the one-pulse timer stops (hardware bus release). */
-        T1.CCMR1 = TIM_CCMR1(OC1M_0, OC1M_1, OC1M_2, OC1PE);
-        T1.CCER = TIM_CCER(CC1E);
+        T1.CCMR2 = TIM_CCMR2(OC3M_0, OC3M_1, OC3M_2, OC3PE);
+        T1.CCER = TIM_CCER(CC3E);
         T1.DIER = 0; /* No DMA for a single bit slot */
         ow_port_update_event();
-        T1.CCR1 = 0; /* Preload 0 -> line idles HIGH when the timer stops */
+        T1.CCR3 = 0; /* Preload 0 -> line idles HIGH when the timer stops */
         T1.CR1 = TIM_CR1(OPM, CEN);
         return;
     }
@@ -203,17 +216,17 @@ __STATIC_FORCEINLINE void ow_port_write_slots(const uint8_t* pulses, uint16_t sl
 __STATIC_FORCEINLINE void ow_port_read_pair(volatile uint16_t* edge_out) {
     T1.RCR = 1; /* Two read slots, then a single update event */
     T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND; /* Total bit slot time */
-    T1.CCR1 = ONEWIRE_ONE_PULSE; /* Read pulse duration */
-    T1.CCMR1 = TIM_CCMR1(OC1M_0, OC1M_1, OC1M_2, OC1PE, CC2S_1, OW_PORT_IC2F_ARGS);
-    T1.CCER = TIM_CCER(CC1E, CC2E);
-    T1.DIER = TIM_DIER(CC2DE);
+    T1.CCR3 = ONEWIRE_ONE_PULSE; /* Read pulse duration */
+    T1.CCMR2 = TIM_CCMR2(OC3M_0, OC3M_1, OC3M_2, OC3PE, CC4S_1, OW_PORT_IC4F_ARGS);
+    T1.CCER = TIM_CCER(CC3E, CC4E);
+    T1.DIER = TIM_DIER(CC4DE);
     ow_port_update_event();
-    T1.CCR1 = 0; /* Clear output compare value */
-    D13.CCR = 0;
-    D13.CPAR = (uint32_t)&T1.CCR2;
-    D13.CMAR = (uint32_t)edge_out;
-    D13.CNDTR = 2;
-    D13.CCR = DMA_CCR(MINC, PSIZE_0, MSIZE_0, EN);
+    T1.CCR3 = 0; /* Clear output compare value */
+    OW_PORT_DMA_CAPTURE.CCR = 0;
+    OW_PORT_DMA_CAPTURE.CPAR = (uint32_t)&T1.CCR4;
+    OW_PORT_DMA_CAPTURE.CMAR = (uint32_t)edge_out;
+    OW_PORT_DMA_CAPTURE.CNDTR = 2;
+    OW_PORT_DMA_CAPTURE.CCR = DMA_CCR(MINC, PSIZE_0, MSIZE_0, EN);
     T1.CR1 = TIM_CR1(OPM, CEN);
 }
 
@@ -221,48 +234,48 @@ __STATIC_FORCEINLINE void ow_port_read_pair(volatile uint16_t* edge_out) {
  * @brief Schedule a merged single-slot write followed by a two-slot read pair
  * @param[in] bit Direction bit to write in slot 1 (0 or 1)
  * @param[in] edge3 Buffer for the three captured edges (write slot, id, cmp)
- * @param[in] read_pulse CCR1 reloads for read slots 2-3 (+ trailing 0)
+ * @param[in] read_pulse CCR3 reloads for read slots 2-3 (+ trailing 0)
  */
 __STATIC_FORCEINLINE void ow_port_write_then_read(uint8_t bit, volatile uint16_t* edge3,
-                                                 const uint8_t* read_pulse) {
+                                                  const uint8_t* read_pulse) {
     const uint8_t write_pulse = bit ? (uint8_t)ONEWIRE_ONE_PULSE : (uint8_t)ONEWIRE_ZERO_PULSE;
     T1.RCR = 2; /* Three slots, then a single update event */
     T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND; /* Total bit slot time */
     /* Arm the direction pulse first. The bus was released idle-high by
      * ow_port_bus_done(), so this write produces the single clean falling edge
      * the devices re-sync their slot timer to. Holding it from the top instead
-     * of arming it right before CEN means the CC2 capture is armed while the
+     * of arming it right before CEN means the CC4 capture is armed while the
      * bus is low, so the open-drain RC rise can never be mistaken for a slot
      * edge. */
-    T1.CCR1 = write_pulse; /* Slot 1 write pulse encodes the direction bit */
-    T1.CCR3 = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE; /* End-of-slot reload trigger */
-    /* OC1 in PWM mode (no preload so the reload is immediate), CC2 capture armed */
-    T1.CCMR1 = TIM_CCMR1(OC1M_0, OC1M_1, OC1M_2, CC2S_1, OW_PORT_IC2F_ARGS);
-    T1.CCER = TIM_CCER(CC1E, CC2E); /* Enable both channels */
+    T1.CCR3 = write_pulse; /* Slot 1 write pulse encodes the direction bit */
+    T1.CCR2 = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE; /* End-of-slot reload trigger */
+    /* OC3 in PWM mode (no preload so the reload is immediate), CC4 capture armed */
+    T1.CCMR2 = TIM_CCMR2(OC3M_0, OC3M_1, OC3M_2, CC4S_1, OW_PORT_IC4F_ARGS);
+    T1.CCER = TIM_CCER(CC3E, CC4E); /* Enable both channels */
     /* Disconnect DMA requests while re-arming the channels, then re-connect
      * them only after the timer flags are clean and just before starting.
-     * (The end-of-slot CC3 compare event of the previous merged operation can
+     * (The end-of-slot CC2 compare event of the previous merged operation can
      * leave a pending request that fires the reload DMA immediately on re-arm,
-     * overwriting the freshly written direction pulse in CCR1.) */
+     * overwriting the freshly written direction pulse in CCR3.) */
     T1.DIER = 0;
     ow_port_update_event();
-    /* DMA Ch3: capture all three slot edges into the merged-edge buffer */
-    D13.CCR = 0;
-    D13.CPAR = (uint32_t)&T1.CCR2;
-    D13.CMAR = (uint32_t)edge3;
-    D13.CNDTR = 3;
-    D13.CCR = DMA_CCR(MINC, PSIZE_0, MSIZE_0, EN);
-    /* DMA Ch6: reload CCR1 with the read pulse for slots 2-3, then write the
+    /* Capture DMA: all three slot edges into the merged-edge buffer */
+    OW_PORT_DMA_CAPTURE.CCR = 0;
+    OW_PORT_DMA_CAPTURE.CPAR = (uint32_t)&T1.CCR4;
+    OW_PORT_DMA_CAPTURE.CMAR = (uint32_t)edge3;
+    OW_PORT_DMA_CAPTURE.CNDTR = 3;
+    OW_PORT_DMA_CAPTURE.CCR = DMA_CCR(MINC, PSIZE_0, MSIZE_0, EN);
+    /* Feed DMA: reload CCR3 with the read pulse for slots 2-3, then write the
      * trailing 0 during slot 3 so the one-pulse timer stops with the line
      * released to idle HIGH (hardware bus release). */
-    D16.CCR = 0;
-    D16.CPAR = (uint32_t)&T1.CCR1;
-    D16.CMAR = (uint32_t)read_pulse;
-    D16.CNDTR = 3;
-    D16.CCR = DMA_CCR(DIR, MINC, PSIZE_0, EN);
+    OW_PORT_DMA_FEED.CCR = 0;
+    OW_PORT_DMA_FEED.CPAR = (uint32_t)&T1.CCR3;
+    OW_PORT_DMA_FEED.CMAR = (uint32_t)read_pulse;
+    OW_PORT_DMA_FEED.CNDTR = 3;
+    OW_PORT_DMA_FEED.CCR = DMA_CCR(DIR, MINC, PSIZE_0, EN);
     T1.SR = 0; /* Clear any pending capture/compare flags before enabling DMA requests */
-    T1.DIER = TIM_DIER(CC2DE, CC3DE); /* Capture + CCR1 reload via DMA */
-    T1.CCR1 = write_pulse; /* Re-arm the direction pulse (safe against a stale CC3 DMA reload) */
+    T1.DIER = TIM_DIER(CC4DE, CC2DE); /* Capture + CCR3 reload via DMA */
+    T1.CCR3 = write_pulse; /* Re-arm the direction pulse (safe against a stale CC2 DMA reload) */
     T1.CR1 = TIM_CR1(OPM, CEN);
 }
 
@@ -275,7 +288,7 @@ __STATIC_FORCEINLINE void ow_port_read_data(volatile uint8_t* dst, uint8_t bytes
     const uint16_t bits = (uint16_t)bytes * ONEWIRE_BITS_PER_BYTE;
     T1.RCR = bits - 1;
     T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND;
-    T1.CCR1 = ONEWIRE_ONE_PULSE;
+    T1.CCR3 = ONEWIRE_ONE_PULSE;
     ow_port_capture((volatile void*)dst, bits, 8);
 }
 

--- a/src/onewire.c
+++ b/src/onewire.c
@@ -105,7 +105,7 @@ void onewire_init(void) {
     // No search running after init: lets the slave driver own the timer until
     // the application starts a search.
     search_ctx.finished = 1;
-    // Enable clocks, configure the timer prescaler, PA8 AF open-drain.
+    // Enable clocks, configure the timer prescaler, bus pin AF open-drain.
     ow_port_init();
 }
 

--- a/tests/mock/mock_target.h
+++ b/tests/mock/mock_target.h
@@ -8,12 +8,11 @@
 #include "stm32f1xx.h"
 #endif
 
-/* Semantic aliases over the backend register-layout differences: the PWM
- * output lives on CH1/CCR1 (preload OC1PE in CCMR1) on F1 but moved to
- * CH3/CCR3 (OC3PE in CCMR2) on F0; the capture register is CCR2 vs CCR4,
- * and the slot-end marker compare sits on CC3 (CCR3) vs CC2 (CCR2). The
- * DMA request bits follow their channels. */
-#if defined(OW_PORT_TARGET_F0)
+/* Both backends share the same TIM1 channel roles: PWM output on CH3/CCR3
+ * (preload OC3PE in CCMR2), indirect capture on CH4/CCR4 (IC4 <- TI3), and
+ * the slot-end marker compare on CC2/CCR2. Only the DMA channel numbers and
+ * the GPIO pin configuration differ; those live in the per-target mock
+ * headers via the CMSIS instance names. */
 #define MOCK_TIM_OUT_CCMR (mock_tim1.CCMR2)
 #define MOCK_TIM_OUT_PE TIM_CCMR2_OC3PE
 #define MOCK_TIM_OUT_CCR (mock_tim1.CCR3)
@@ -23,27 +22,4 @@
 #define MOCK_TIM_CAP_DE TIM_DIER_CC4DE
 #define MOCK_TIM_OUT_CCE TIM_CCER_CC3E
 #define MOCK_TIM_CAP_CCE TIM_CCER_CC4E
-/* 1-Wire bus pin: PA8 on F1, PA10 on F0. */
-#define MOCK_BUS_MODER_1 GPIO_MODER_MODER10_1
-#define MOCK_BUS_MODER_0 GPIO_MODER_MODER10_0
-#define MOCK_BUS_OT GPIO_OTYPER_OT_10
-#define MOCK_BUS_AFSEL GPIO_AFRH_AFSEL10
-#define MOCK_BUS_AFSEL_POS GPIO_AFRH_AFSEL10_Pos
-#else
-#define MOCK_TIM_OUT_CCMR (mock_tim1.CCMR1)
-#define MOCK_TIM_OUT_PE TIM_CCMR1_OC1PE
-#define MOCK_TIM_OUT_CCR (mock_tim1.CCR1)
-#define MOCK_TIM_MARKER_CCR (mock_tim1.CCR3)
-#define MOCK_TIM_CAP_CCR (mock_tim1.CCR2)
-#define MOCK_TIM_FEED_DE TIM_DIER_CC3DE
-#define MOCK_TIM_CAP_DE TIM_DIER_CC2DE
-#define MOCK_TIM_OUT_CCE TIM_CCER_CC1E
-#define MOCK_TIM_CAP_CCE TIM_CCER_CC2E
-/* 1-Wire bus pin: PA8 on F1, PA10 on F0. */
-#define MOCK_BUS_MODER_1 GPIO_MODER_MODER8_1
-#define MOCK_BUS_MODER_0 GPIO_MODER_MODER8_0
-#define MOCK_BUS_OT GPIO_OTYPER_OT_8
-#define MOCK_BUS_AFSEL GPIO_AFRH_AFSEL8
-#define MOCK_BUS_AFSEL_POS GPIO_AFRH_AFSEL8_Pos
-#endif
 #endif /* MOCK_TARGET_H */

--- a/tests/mock/stm32f1xx.h
+++ b/tests/mock/stm32f1xx.h
@@ -59,45 +59,45 @@ typedef struct {
     volatile uint32_t CSR;
 } RCC_TypeDef;
 
-/* Instances: pointers so macro.h's (*TIM1), (*DMA1_Channel3), etc. work. */
+/* Instances: pointers so macro.h's (*TIM1), (*DMA1_Channel2), etc. work.
+ * STM32F103 fixed request map (RM0008 table 78): feed rides TIM1_CC2 ->
+ * channel 2, capture rides TIM1_CH4 -> channel 4. The storage objects keep
+ * their legacy names so tests and hw_model stay target-agnostic. */
 extern TIM1_TypeDef mock_tim1;
 extern DMA1_Channel_TypeDef mock_dma1_ch3;
-extern DMA1_Channel_TypeDef mock_dma1_ch6;
+extern DMA1_Channel_TypeDef mock_feed_ch;
 extern GPIO_TypeDef mock_gpioa;
 extern RCC_TypeDef mock_rcc;
 #define TIM1 (&mock_tim1)
-#define DMA1_Channel3 (&mock_dma1_ch3)
-#define DMA1_Channel6 (&mock_dma1_ch6)
+#define DMA1_Channel2 (&mock_feed_ch) /* CC2 slot-end marker -> feeds CCR3 */
+#define DMA1_Channel4 (&mock_dma1_ch3) /* CC4 capture -> drains CCR4 */
 #define GPIOA (&mock_gpioa)
 #define RCC (&mock_rcc)
-
-/* The CCR1 reload feed channel: DMA1 channel 6 on F1 (TIM1_CH3 request). */
-#define mock_feed_ch mock_dma1_ch6
 
 /* --- Bit-field constants used by the driver --- */
 #define RCC_APB2ENR_IOPAEN 0x00000004u
 #define RCC_APB2ENR_TIM1EN 0x00000800u
 #define RCC_AHBENR_DMA1EN 0x00000001u
-#define GPIO_CRH_CNF8_0 0x00000800u
-#define GPIO_CRH_CNF8_1 0x00001000u
-#define GPIO_CRH_MODE8_1 0x00000200u
+#define GPIO_CRH_CNF10_0 0x00000400u
+#define GPIO_CRH_CNF10_1 0x00000800u
+#define GPIO_CRH_MODE10_1 0x00000200u
 #define TIM_BDTR_MOE 0x00008000u
 #define TIM_EGR_UG 0x00000001u
 #define TIM_SR_UIF 0x00000001u
 #define TIM_CR1_CEN 0x00000001u
 #define TIM_CR1_OPM 0x00000008u
-#define TIM_CCMR1_OC1M_0 0x00000010u
-#define TIM_CCMR1_OC1M_1 0x00000020u
-#define TIM_CCMR1_OC1M_2 0x00000040u
-#define TIM_CCMR1_OC1PE 0x00000080u
-#define TIM_CCMR1_CC2S_1 0x00000200u
-#define TIM_CCMR1_IC2F_0 0x00001000u
-#define TIM_CCMR1_IC2F_1 0x00002000u
-#define TIM_CCMR1_IC2F_2 0x00004000u
-#define TIM_CCER_CC1E 0x00000001u
-#define TIM_CCER_CC2E 0x00000010u
+#define TIM_CCMR2_OC3M_0 0x00000010u
+#define TIM_CCMR2_OC3M_1 0x00000020u
+#define TIM_CCMR2_OC3M_2 0x00000040u
+#define TIM_CCMR2_OC3PE 0x00000008u
+#define TIM_CCMR2_CC4S_1 0x00000200u
+#define TIM_CCMR2_IC4F_0 0x00001000u
+#define TIM_CCMR2_IC4F_1 0x00002000u
+#define TIM_CCMR2_IC4F_2 0x00004000u
+#define TIM_CCER_CC3E 0x00000100u
+#define TIM_CCER_CC4E 0x00001000u
 #define TIM_DIER_CC2DE 0x00000400u
-#define TIM_DIER_CC3DE 0x00000800u
+#define TIM_DIER_CC4DE 0x00004000u
 #define DMA_CCR_EN 0x00000001u
 #define DMA_CCR_DIR 0x00000010u
 #define DMA_CCR_MINC 0x00000080u

--- a/tests/test/test_alarm_search.c
+++ b/tests/test/test_alarm_search.c
@@ -112,7 +112,7 @@ static void setup_single_device(void) {
 
 /*-------------------------------------------------------------
  *  The alarm search finds the single alarmed device and puts the
- *  0xEC command byte on the wire. The CCR1 feed is pulses[1..7]
+ *  0xEC command byte on the wire. The CCR3 feed is pulses[1..7]
  *  of the LSB-first 0xEC encoding plus the trailing bus-release
  *  zero: 0xEC = 1110 1100 -> LSB-first bits 0,0,1,1,0,1,1,1
  *  -> pulses ZERO,ZERO,ONE,ONE,ZERO,ONE,ONE,ONE -> feed

--- a/tests/test/test_alarm_thresholds.c
+++ b/tests/test/test_alarm_thresholds.c
@@ -8,7 +8,7 @@
  *     ROM modes, with TH/TL in the user payload and the current
  *     resolution preserved in the CFG byte
  *   - a full non-blocking threshold write over the TIM1/DMA model
- *     with the trailing bus-release zero in the CCR1 feed
+ *     with the trailing bus-release zero in the CCR3 feed
  *   - raw 9-byte scratchpad read-back including TH/TL and the CRC
  *   - resolution auto-derivation from a valid config byte only
  *   - presence-abort and re-entry guards

--- a/tests/test/test_bus_release.c
+++ b/tests/test/test_bus_release.c
@@ -8,9 +8,9 @@
  *  how long software takes to poll:
  *
  *    - DMA-fed writes (send_command_n, write_then_read) append
- *      a trailing 0 to the CCR1 feed -> last DMA value is 0.
+ *      a trailing 0 to the CCR3 feed -> last DMA value is 0.
  *    - direct-write/capture ops (reset, read, single slot) use
- *      an OC1PE preload of 0 -> shadow CCR1 is 0 at the
+ *      an OC3PE preload of 0 -> shadow CCR3 is 0 at the
  *      terminal update event (OPM stop).
  *
  *  The model asserts the resulting invariant directly:
@@ -65,7 +65,7 @@ void test_write_command_trailing_zero_release(void) {
     }
     cmd[16] = 0; /* trailing bus-release zero at index `slots` */
 
-    hw_register_buf(&cmd[1]); /* the driver feeds CCR1 from &cmd[1] */
+    hw_register_buf(&cmd[1]); /* the driver feeds CCR3 from &cmd[1] */
     hw_set_capture_source(NULL);
     test_bus_send_command_n(cmd, 16);
     complete_op(20);
@@ -80,7 +80,7 @@ void test_write_command_trailing_zero_release(void) {
 }
 
 /*-------------------------------------------------------------
- *  Single-slot write (no DMA): OC1PE preload 0 armed before
+ *  Single-slot write (no DMA): OC3PE preload 0 armed before
  *  the timer starts; bus released when the timer stops.
  * -----------------------------------------------------------*/
 void test_single_slot_write_preload_zero(void) {
@@ -197,7 +197,7 @@ void test_sequence_stays_released_between_ops(void) {
 }
 
 /*-------------------------------------------------------------
- *  Standalone read_pair (rcr=1, 2 captures): OC1PE preload 0,
+ *  Standalone read_pair (rcr=1, 2 captures): OC3PE preload 0,
  *  id/cmp decoded from ctx.edge, bus released on completion.
  * -----------------------------------------------------------*/
 void test_read_pair_standalone_release(void) {
@@ -221,7 +221,7 @@ void test_read_pair_standalone_release(void) {
 
 /*-------------------------------------------------------------
  *  Long pure-timer waits (wait_conversion = 750ms, RCR=11;
- *  start_cycle_pause = 5s, RCR=79). They never touch CCR1,
+ *  start_cycle_pause = 5s, RCR=79). They never touch CCR3,
  *  so the line stays idle HIGH for the whole wait and the bus
  *  is still released when the timer stops.
  * -----------------------------------------------------------*/

--- a/tests/test/test_read_rom.c
+++ b/tests/test/test_read_rom.c
@@ -3,7 +3,7 @@
  *
  *  Covers the non-blocking ds18b20_read_rom()/poll() pair:
  *   - the bare command (no addressing prefix) pulse build and the
- *     trailing bus-release zero in the CCR1 feed
+ *     trailing bus-release zero in the CCR3 feed
  *   - a full read-back of the 8-byte ROM over the TIM1/DMA model
  *   - presence-abort leaves the result buffer untouched
  *   - ownership guards (mid-measurement, search, resolution, re-entry)

--- a/tests/test/test_resolution.c
+++ b/tests/test/test_resolution.c
@@ -6,7 +6,7 @@
  *  machine against the TIM1/DMA hardware model:
  *   - wait timing table for 9/10/11/12 bit (exact minimum waits)
  *   - the config write sequence (Skip ROM and Match ROM) with the
- *     trailing bus-release zero in the CCR1 feed
+ *     trailing bus-release zero in the CCR3 feed
  *   - ownership guards (mid-measurement, search, re-entry, range)
  *   - presence-abort without adopting the new resolution
  *   - auto-derivation of the resolution from a valid scratchpad
@@ -257,7 +257,7 @@ void test_resolution_no_presence_aborts(void) {
     drive_res_change(9);
     /* No config write happened: the resolution must NOT be adopted. */
     TEST_ASSERT_EQUAL_UINT8(12, ds18b20_get_resolution());
-    /* The last simulated operation was only the presence reset: no CCR1 feed
+    /* The last simulated operation was only the presence reset: no CCR3 feed
      * (i.e. no config write) was ever sent to the bus. */
     TEST_ASSERT_EQUAL_UINT8(0, hw_ccr1_feed_log()->count);
     TEST_ASSERT_EQUAL_UINT8(1, ds18b20_set_resolution_poll()); /* finished */

--- a/tests/test/test_search.c
+++ b/tests/test/test_search.c
@@ -89,7 +89,7 @@ void test_search_finds_single_device(void) {
 
 /*-------------------------------------------------------------
  *  The 0xF0 Search ROM command is DMA-fed (8 slot pulses) and
- *  must end with a trailing 0 in the CCR1 feed so the bus is
+ *  must end with a trailing 0 in the CCR3 feed so the bus is
  *  released HIGH even before the next read_pair is scheduled.
  *  After the whole search completes (DONE phase, EGR=UG hand-
  *  over) the bus must still be idle HIGH.
@@ -238,7 +238,7 @@ void test_search_no_device_no_presence(void) {
 
 /*-------------------------------------------------------------
  *  write_then_read arms the merged op: 3-slot timer pass, PWM
- *  WITHOUT OC1PE (so the CC3 DMA reload is immediate), capture
+ *  WITHOUT OC3PE (so the CC2 DMA reload is immediate), capture
  *  DMA for 3 edges and reload DMA feeding {ONE,ONE,0}.
  * -----------------------------------------------------------*/
 void test_write_then_read_configures_registers(void) {

--- a/tests/test/test_state_machine.c
+++ b/tests/test/test_state_machine.c
@@ -778,18 +778,18 @@ void test_state_machine_init_configures_registers(void) {
     TEST_ASSERT_BITS_HIGH(RCC_AHBENR_GPIOAEN | RCC_AHBENR_DMAEN, mock_rcc.AHBENR);
     TEST_ASSERT_EQUAL_UINT32(47, mock_tim1.PSC); /* 48MHz/48 = 1MHz -> 1us */
     TEST_ASSERT_BITS_HIGH(TIM_BDTR_MOE, mock_tim1.BDTR);
-    /* Bus pin: AF mode (MODERx_1), open-drain, AF2 in AFRH */
-    TEST_ASSERT_BITS_HIGH(MOCK_BUS_MODER_1, mock_gpioa.MODER);
-    TEST_ASSERT_BITS_LOW(MOCK_BUS_MODER_0, mock_gpioa.MODER);
-    TEST_ASSERT_BITS_HIGH(MOCK_BUS_OT, mock_gpioa.OTYPER);
-    TEST_ASSERT_EQUAL_UINT32(2u << MOCK_BUS_AFSEL_POS,
-                             mock_gpioa.AFR[1] & MOCK_BUS_AFSEL);
+    /* Bus pin PA10: AF mode (MODER10_1), open-drain, AF2 in AFRH */
+    TEST_ASSERT_BITS_HIGH(GPIO_MODER_MODER10_1, mock_gpioa.MODER);
+    TEST_ASSERT_BITS_LOW(GPIO_MODER_MODER10_0, mock_gpioa.MODER);
+    TEST_ASSERT_BITS_HIGH(GPIO_OTYPER_OT_10, mock_gpioa.OTYPER);
+    TEST_ASSERT_EQUAL_UINT32(2u << GPIO_AFRH_AFSEL10_Pos,
+                             mock_gpioa.AFR[1] & GPIO_AFRH_AFSEL10);
 #else
     TEST_ASSERT_BITS_HIGH(RCC_APB2ENR_IOPAEN | RCC_APB2ENR_TIM1EN, mock_rcc.APB2ENR);
     TEST_ASSERT_BITS_HIGH(RCC_AHBENR_DMA1EN, mock_rcc.AHBENR);
     TEST_ASSERT_EQUAL_UINT32(71, mock_tim1.PSC); /* 72MHz/72 = 1MHz -> 1us */
     TEST_ASSERT_BITS_HIGH(TIM_BDTR_MOE, mock_tim1.BDTR);
-    TEST_ASSERT_BITS_HIGH(GPIO_CRH_CNF8_0 | GPIO_CRH_CNF8_1 | GPIO_CRH_MODE8_1, mock_gpioa.CRH);
+    TEST_ASSERT_BITS_HIGH(GPIO_CRH_CNF10_0 | GPIO_CRH_CNF10_1 | GPIO_CRH_MODE10_1, mock_gpioa.CRH);
 #endif
 }
 

--- a/tests/test/test_timing.c
+++ b/tests/test/test_timing.c
@@ -2,7 +2,7 @@
  *  test_timing.c - Timing Register Regression Tests
  *
  *  Verifies the actual register values each bus operation programs
- *  into TIM1 (ARR/RCR/CCR1/CCR3) against the DS18B20 timing spec.
+ *  into TIM1 (ARR/RCR/CCR2/CCR3) against the DS18B20 timing spec.
  *  Unlike a constant re-check, this locks the real driver output.
  * ============================================================ */
 


### PR DESCRIPTION
## Summary

The STM32F1 backend now uses the exact same TIM1 channel roles as the
STM32F0 backend, so both share one register-level model:

| Role | Before (F1) | After (F1 = F0) |
|---|---|---|
| Bus / PWM output | CH1/CCR1 on **PA8** | CH3/CCR3 on **PA10** |
| Indirect capture | IC2<-TI1 -> CCR2 | IC4<-TI3 -> CCR4 |
| Slot-end marker | CC3/CCR3 | CC2/CCR2 |
| Feed DMA | Ch6 -> CCR1 (CC3DE) | **Ch2** -> CCR3 (CC2DE) |
| Capture DMA | Ch3 <- CCR2 | **Ch4** <- CCR4 (CC4DE) |

Only the prescaler, GPIO pin configuration and the two DMA channel numbers
(fixed request map, RM0008 table 78) differ between backends now. PA10 is
free on Blue Pill: it is USART1_RX and the demos are TX-only; USART1_TX
shares channel 4's request line but the UART runs without DMA.

**BREAKING:** existing F1 wiring must move DQ from PA8 to PA10 (next
release will be v1.5.0).

Mock/test fallout: DMA1_Channel2->feed / DMA1_Channel4->capture storage,
target-conditional MOCK_TIM_* aliases collapsed into one block, MOCK_BUS_*
removed, stale CCR1/OC1PE doc comments fixed.

## Validation
- `make test` + `make test-f0`: 221 + 221 tests, 0 failures
- Build matrix demo..demo4 x {72MHz, HSI 8MHz}: all OK
- clang-format 18.1.8 clean on CI-checked files; cppcheck clean