### PR TITLE
Exp/parasite guard band

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the full report over UART and resets for the next window.  Validated on
   STM32G031@64MHz with 6 × DS18B20 in parasite power mode — all sensors
   detected, 0 errors, pulse widths 5–32 µs.
+- Example application `src/demo1.c` (`make APP=demo1`): startup device
+  search + per-device polling.  Each discovered sensor is converted and read
+  back individually via Match ROM (one `Convert T` per device, no broadcast
+  conversion) — the minimal multi-sensor counterpart to `demo3`'s
+  simultaneous scan.  Parasite power is engaged with `EXT="-DPARASITE_POWER=1"`;
+  note that per-device MATCH-ROM conversion is the marginal topology on a
+  parasite bus, so a broadcast convert (demo3) is preferred there.
+- Timing profiles (`inc/onewire.h`, `src/onewire.c`): four selectable slot
+  timings spanning fastest-to-slowest, all inside the DS18B20 1-Wire
+  specification — `ONEWIRE_TIMING_FAST` (5/60/3µs, 50µs parasite guard),
+  `ONEWIRE_TIMING_STANDARD` (5/60/5µs, 100µs; equals the historical defaults),
+  `ONEWIRE_TIMING_SLOW` (8/90/20µs, 200µs) and `ONEWIRE_TIMING_ROBUST`
+  (10/110/30µs, 250µs).  Select at runtime with
+  `onewire_set_timing_profile()` (or pin a compile-time default via
+  `ONEWIRE_TIMING_PROFILE_DEFAULT`); `onewire_get_timing_profile()` reports the
+  active one.  The `one_pulse`/`zero_pulse`/`guard_band`/`parasite_guard_band`/
+  `short_pulse_max` fields drive the timer ARR, the write low-time and the
+  read-decode threshold, so each profile adapts to different wire lengths and
+  sensor tolerances without touching the per-port timer code.  `onewire_init()`
+  applies the default profile; `ow_set_parasite_guard()` keeps the per-profile
+  external/parasite guard-band split.
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,20 @@
 # Select the example application: demo (single sensor, Skip ROM),
+# demo1 (device search + sequential polling of every sensor, one Convert T
+#        per device - no broadcast conversion),
 # demo2 (device search + sequential polling of every sensor on the bus),
 # demo3 (device search + simultaneous broadcast conversion of every sensor),
 # demo4 (device search + command transactions: ROM, power supply, TH/TL,
 #        Copy/Recall EEPROM)
 # demo5 (device search + sequential polling with signal statistics)
 #   make               -> builds demo   (ds18b20_demo.elf)
+#   make APP=demo1     -> builds demo1  (ds18b20_demo1.elf)
 #   make APP=demo2     -> builds demo2  (ds18b20_demo2.elf)
 #   make APP=demo3     -> builds demo3  (ds18b20_demo3.elf)
 #   make APP=demo4     -> builds demo4  (ds18b20_demo4.elf)
 #   make APP=demo5     -> builds demo5  (ds18b20_demo5.elf)
 APP ?= demo
-ifeq ($(filter $(APP),demo demo2 demo3 demo4 demo5),)
-$(error APP must be 'demo', 'demo2', 'demo3', 'demo4' or 'demo5')
+ifeq ($(filter $(APP),demo demo1 demo2 demo3 demo4 demo5),)
+$(error APP must be 'demo', 'demo1', 'demo2', 'demo3', 'demo4' or 'demo5')
 endif
 
 # demo5 is the signal-statistics example: enable the optional stats module by
@@ -63,6 +66,7 @@ INC = -I. -Iinc -Iport/stm32f1 -Iport/stm32f0 -Iport/stm32g0 -I$(CMSIS_CORE_DIR)
 
 # Per-app USART1 TX ring buffer size (power of two), overrides the app.h default
 UART_TX_SIZE_demo  = 128
+UART_TX_SIZE_demo1 = 256
 UART_TX_SIZE_demo2 = 256
 UART_TX_SIZE_demo3 = 256
 UART_TX_SIZE_demo4 = 256
@@ -468,10 +472,12 @@ TEST_SRC  = $(TEST_DIR)/test_main.c \
             $(TEST_DIR)/test_parasite.c \
             $(TEST_DIR)/test_dmamux.c \
             $(TEST_DIR)/test_ow_stats.c \
-            $(TEST_MOCK)/hw_model.c \
+             $(TEST_MOCK)/hw_model.c \
             $(TEST_MOCK)/ds18b20_test_spy.c \
             $(TEST_MOCK)/ds18b20_test_access.c \
-            $(TEST_MOCK)/ow_stats_test_access.c
+            $(TEST_MOCK)/ow_stats_test_access.c \
+            $(TEST_DIR)/test_harness_api.c \
+            $(TEST_DIR)/test_app_uart.c
 # Pointer<->register casts (driver targets a 32-bit Cortex-M3) are expected
 # on a 64-bit host; suppress the size warnings.
 # OW_TARGET=f0 runs the same suite against the STM32F0 backend mock,
@@ -530,7 +536,7 @@ help:
 	@echo "  gccversion      - Show compiler version"
 	@echo "  help            - Show this help"
 	@echo "Variables:"
-	@echo "  APP=demo|demo2|demo3|demo4  - example application to build"
+	@echo "  APP=demo|demo1|demo2|demo3|demo4|demo5  - example application to build"
 	@echo "  OW_TARGET=f1|f0|g0               - MCU family (firmware build)"
 	@echo "  SYSCLK_MHZ=N                     - run on the raw internal RC (8MHz F1/F0, 16MHz G0) instead of family default"
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The core (`src/onewire.c` + `src/ds18b20.c`) is MCU-independent and rides on a s
 ├── src/                    # Project source files
 │   ├── app.c               # app_init(), UART TX ring buffer, busy LED
 │   ├── demo.c              # Example: single sensor, unconditional (Skip ROM)
+│   ├── demo1.c             # Example: device search + per-device poll (no broadcast convert)
 │   ├── demo2.c             # Example: device search + sequential poll of all
 │   ├── demo3.c             # Example: device search + simultaneous conversion
 │   ├── demo4.c             # Example: device search + command transactions
@@ -114,6 +115,11 @@ The core (`src/onewire.c` + `src/ds18b20.c`) is MCU-independent and rides on a s
 │   ├── onewire.c           # 1-Wire layer: state machine + bus primitives
 │   │                       #               + non-blocking Search ROM engine
 │   └── ds18b20.c           # Driver: DS18B20 command set on the 1-Wire layer
+├── tests/                  # Host test suite (no hardware required)
+│   ├── mock/               # Behavioural TIM1/DMA model + register mocks
+│   └── test/               # Unity-based test cases
+├── docs/                   # Documentation assets
+│   └── screenshots/        # UART capture screenshots
 ├── CMSIS/                  # Build-time dependencies (gitignored)
 │   ├── core/               # ARM CMSIS 5 core headers
 │   └── device/             # STM32F1 device headers and startup
@@ -130,22 +136,24 @@ The core (`src/onewire.c` + `src/ds18b20.c`) is MCU-independent and rides on a s
 
 ## Examples
 
-Five ready-to-run example applications are provided; select one with `APP`:
+Six ready-to-run example applications are provided; select one with `APP`:
 
 | APP     | File             | Behaviour                                                        |
 |---------|------------------|------------------------------------------------------------------|
 | `demo`  | `src/demo.c`     | Unconditional polling of a single DS18B20 via Skip ROM (0xCC).   |
+| `demo1` | `src/demo1.c`    | Startup device search + per-device polling: each sensor is converted and read back individually via Match ROM (one `Convert T` per device, no broadcast conversion). |
 | `demo2` | `src/demo2.c`    | Startup device search + sequential polling of every sensor found (up to `DS18B20_SEARCH_MAX_DEVICES`). |
 | `demo3` | `src/demo3.c`    | Startup device search + simultaneous broadcast conversion: one `Convert T` (Skip ROM) converts all sensors in parallel, then each is read back via Match ROM. |
 | `demo4` | `src/demo4.c`    | Startup device search + non-blocking command transactions on the first sensor: Read Power Supply (0xB4), raw Read Scratchpad (0xBE), Write Scratchpad TH/TL (0x4E), Copy Scratchpad (0x48) to the EEPROM, Recall EEPROM (0xB8), single-device Read ROM (0x33), then steady-state measurement of the selected device. |
-| `demo5` | `src/demo5.c`    | Startup device search + sequential measurement with signal statistics. Accumulates per-sensor pulse-width min/max, a global histogram and error counters over N cycles (default 100, configurable via `STATS_DUMP_INTERVAL`), then streams the full report over UART as a non-blocking dump. Requires `-DOW_STATS_ENABLE`. |
+| `demo5` | `src/demo5.c`    | Startup device search + sequential measurement with signal statistics. The `demo5` target auto-enables `-DOW_STATS_ENABLE`. Accumulates per-sensor pulse-width min/max, a global histogram and error counters over N cycles (shipped build default 5000 via `STATS_DUMP_INTERVAL`, overridable), then streams the full report over UART as a non-blocking dump. |
 
 ```bash
 make                # build demo  -> build/ds18b20_demo.elf
+make APP=demo1      # build demo1 -> build/ds18b20_demo1.elf
 make APP=demo2      # build demo2 -> build/ds18b20_demo2.elf
 make APP=demo3      # build demo3 -> build/ds18b20_demo3.elf
 make APP=demo4      # build demo4 -> build/ds18b20_demo4.elf
-make APP=demo5 EXT=-DOW_STATS_ENABLE   # build demo5 -> build/ds18b20_demo5.elf
+make APP=demo5                   # build demo5 -> build/ds18b20_demo5.elf (OW_STATS_ENABLE auto-added)
 make debug APP=demo2  # debug build of demo2 (for J-Link/ST-Link)
 
 # STM32F030 target (same examples, bus on PA10):
@@ -436,6 +444,9 @@ Output goes to `build/` (`ds18b20_demo.elf`, `.hex`, `.bin`).
 | `make clean-deps` | Remove downloaded dependencies |
 | `make program` | Flash via ST-LINK |
 | `make jprogram` | Flash via J-LINK |
+| `make test-f0` | Build and run host tests against the STM32F0 backend mock |
+| `make test-g0` | Build and run host tests against the STM32G0 backend mock |
+| `make test COVERAGE=1` | Host tests with gcov instrumentation (coverage report) |
 | `make help` | Show all targets |
 
 ### Flash
@@ -648,12 +659,12 @@ complete `onewire_*` surface.
        with a low (active) portion encoding the bit:
        - Short low (~5µs) → logical '1'
        - Long low (~60µs) → logical '0'
-     - Total slot = `ONE_PULSE + ZERO_PULSE + guard` = 5 + 60 + 5 = 70µs.
+      - Total slot = `ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND` = 5 + 60 + 5 = 70µs (the STANDARD timing profile default; see Configuration → Timing Profiles).
        The +5µs guard band prevents overlap between consecutive slots
        due to bus rise time and DMA latency.
     - Reset (~480µs) is generated as an extended low period (active-low) within a ~960µs slot.
   - CH4 (Input Capture, Indirect mode): Shares the same PA10 pin internally. Used to capture presence pulses and read-slot timings after CH3 releases the bus to idle-high; DMA transfers CCR4 capture values to memory.
-  - CH2: End-of-slot marker (a plain compare at ONE+ZERO µs); its DMA request feeds CCR3 duty cycles for the CH3 output.
+   - CH2: End-of-slot marker (a plain compare at `ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE` µs); its DMA request feeds CCR3 duty cycles for the CH3 output.
 - RCR (Repetition Counter Register): Key to the state machine operation. Instead of generating an Update Event on every period, RCR controls how many timer repetitions occur before UIF is set.
   - Example: RCR=15 → the timer generates 16 PWM slots (bits) via DMA, then asserts UIF once at the end, signaling software to proceed.
   - This allows grouping a full command (two bytes), the entire 72-bit read, or long delays into single hardware-driven transactions, freeing the CPU until completion.
@@ -868,7 +879,7 @@ void        onewire_pair_bits(const volatile uint16_t *edge,
                               uint8_t *id_bit, uint8_t *cmp_bit);
 void        onewire_read_data(volatile uint8_t *dst, uint8_t bytes);
 void        onewire_decode_pulses(uint8_t *dst, const volatile uint8_t *pulse,
-                                 uint8_t bytes);
+                                 uint8_t nbytes);
 void        onewire_start_timer(uint16_t arr, uint8_t rcr);
 uint8_t     onewire_crc8(const uint8_t *data, uint8_t len);
 void        onewire_search_start(onewire_search_sink_t sink,
@@ -878,6 +889,37 @@ uint8_t     onewire_search_poll(void);
 uint8_t     onewire_search_count(void);
 uint8_t     onewire_search_active(void);
 ```
+
+#### Timing Profiles
+
+The slot timing is selected at **runtime** from four built-in profiles
+(`inc/onewire.h`); `ONEWIRE_TIMING_PROFILE_DEFAULT` chooses the compile-time
+default (`ONEWIRE_TIMING_STANDARD`). Switching profiles is non-blocking and
+applies immediately to every subsequent bus operation, including the Search ROM
+engine. See [Configuration → Timing Profiles](#timing-profiles) for the full
+per-profile value table.
+
+```C
+typedef enum {
+    ONEWIRE_TIMING_FAST = 0,
+    ONEWIRE_TIMING_STANDARD,
+    ONEWIRE_TIMING_SLOW,
+    ONEWIRE_TIMING_ROBUST,
+    ONEWIRE_TIMING_COUNT
+} onewire_timing_profile_t;
+
+void onewire_set_timing_profile(onewire_timing_profile_t profile);
+onewire_timing_profile_t onewire_get_timing_profile(void);
+void ow_set_parasite_guard(uint8_t parasite);   /* 0 = standard guard, !=0 = parasite guard */
+void onewire_strong_pullup(uint8_t on);          /* parasite power: drive bus HIGH */
+```
+
+The macro `ONEWIRE_TIMING_PROFILE_DEFAULT` chooses the compile-time default;
+override it on the command line (e.g.
+`-DONEWIRE_TIMING_PROFILE_DEFAULT=ONEWIRE_TIMING_SLOW`) to ship a different
+default without touching the call site. The live values are also exposed as the
+runtime globals `ow_one_pulse_us`, `ow_zero_pulse_us`, `ow_guard_band_us` and
+`ow_short_pulse_max_us`.
 
 Any other 1-Wire slave driver can use the same layer. The DS18B20 driver calls
 `onewire_init()` from `ds18b20_init()` and keeps the layer's Search ROM engine
@@ -1126,14 +1168,15 @@ void ow_stats_count_error(int16_t error, const uint8_t *rom);
 void ow_stats_dump_start(void);
 uint8_t ow_stats_dump_poll(void);
 void ow_stats_reset(void);
-uint16_t ow_stats_tick(void);
+uint32_t ow_stats_tick(void);
 ```
 
 - `ow_stats_init()` — zero-initialise the statistics context.  Call once at
   startup.
 - `ow_stats_capture_pulse()` — snapshot raw pulse widths before
   `decode_scratchpad()` overwrites the capture buffer via the union alias.
-  Updates the 13-bucket logarithmic histogram (0–60+ µs, buckets covering
+  Updates the 13-bucket logarithmic histogram (0–60+ µs; 13 of the 16
+  `OW_STATS_HIST_BUCKETS` array slots are populated, indices 0–12) covering
   0–2, 3–4, 5–6, 7–9, 10–12, 13–14, 15–19, 20–24, 25–29, 30–39,
   40–49, 50–59, 60+ µs) and per-sensor min/max pulse counters.  Called
   automatically from `ds18b20.c` when `OW_STATS_ENABLE` is defined.
@@ -1150,7 +1193,9 @@ uint16_t ow_stats_tick(void);
   ROM table.  Call after `ow_stats_dump_poll()` returns 1.
 - `ow_stats_tick()` — increment the cycle counter; returns the new value.
 
-RAM cost: ~180 bytes (8 sensors × 18 + 16 histogram buckets × 2 + 5).
+RAM cost: ~290 bytes (8 sensors × 26 B + 16-entry `uint32_t` histogram [64 B] +
+cycle/error counters; 13 of the 16 histogram buckets, indices 0–12, are
+populated).
 
 Example — dump every 100 cycles:
 
@@ -1161,7 +1206,7 @@ static uint8_t dump_busy = 0;
 
 void ds18b20_complete(int16_t temp) {
     // ... handle temperature reading ...
-    uint16_t cycles = ow_stats_tick();
+    uint32_t cycles = ow_stats_tick();
     if (cycles >= 100 && !dump_busy) {
         ow_stats_dump_start();
         dump_busy = 1;
@@ -1187,9 +1232,14 @@ int main(void) {
 Build with the statistics module:
 
 ```sh
-make APP=demo5 EXT="-DOW_STATS_ENABLE"                # external power
-make APP=demo5 EXT="-DOW_STATS_ENABLE -DPARASITE_POWER=1"  # parasite power
+make APP=demo5                                  # external power (OW_STATS_ENABLE auto-added)
+make APP=demo5 EXT="-DPARASITE_POWER=1"            # parasite power
 ```
+
+> Note: the `demo5` target already injects `-DOW_STATS_ENABLE` plus
+> `-DSTATS_DUMP_INTERVAL=5000 -DDS18B20_CYCLE_PAUSE_US=10000`, so the shipped
+> demo5 dumps every 5000 cycles with a 10 s inter-cycle pause. Override either
+> macro via `EXT=` if you want the module defaults instead.
 
 UART output format (compact, one sensor per line):
 
@@ -1269,31 +1319,56 @@ Called when a measurement cycle completes — provides temperature data in tenth
 - Time to result (one measurement): 93.75ms @ 9-bit … ~0.76 s @ 12-bit
   (conversion + protocol overhead; the conversion wait follows the configured
   resolution, see `ds18b20_set_resolution()`)
-- Inter-measurement pause: 5 s (configurable)
+- Inter-measurement pause: 5 s, configurable via `DS18B20_CYCLE_PAUSE_US` (default 5000000 µs; the demo5 build overrides it to 10000 µs)
 - Precision: 0.1°C resolution at 12-bit (coarser steps at lower resolutions)
 - Accuracy: ±0.5°C (typical)
 - CPU Usage: Minimal; CPU is free to perform other tasks during waits.
 
 ## Configuration
 
-### Timing Constants
+### Timing Profiles
 
-The slot-pulse constants live in `inc/onewire.h` (with the `ONEWIRE_` prefix;
-`src/ds18b20.c` re-exports them as `ONE_PULSE` / `ZERO_PULSE` / `GUARD_BAND`).
-The reset-pulse bounds are defined in `src/onewire.c`:
+The 1-Wire slot timing is selected at runtime from four built-in profiles
+(see also the [API Reference → Timing Profiles](#timing-profiles)). The default
+profile is `ONEWIRE_TIMING_PROFILE_DEFAULT` (`ONEWIRE_TIMING_STANDARD`); override
+it at compile time with
+`-DONEWIRE_TIMING_PROFILE_DEFAULT=ONEWIRE_TIMING_SLOW` if you want a different
+out-of-reset timing without changing the call site.
+
+The fixed `ONEWIRE_*` macros in `inc/onewire.h` are the **STANDARD** profile
+values (and the initial runtime defaults); the reset-pulse bounds are defined in
+`src/onewire.c`:
 
 ```C
-/* inc/onewire.h */
+/* inc/onewire.h — STANDARD profile defaults */
 #define ONEWIRE_ONE_PULSE           5     // µs (short low = write-1)
 #define ONEWIRE_ZERO_PULSE         60    // µs (long low = write-0)
-#define ONEWIRE_GUARD_BAND          5    // µs (built into slot formula)
+#define ONEWIRE_GUARD_BAND          5     // µs (built into slot formula)
 #define ONEWIRE_SHORT_PULSE_MAX    10    // µs (pulse <= this reads as bit '1')
 
 /* src/onewire.c */
 #define RESET_PULSE_MIN           480U    // µs
 #define RESET_PULSE_MAX           540U    // µs
 ```
-Slot formula: `ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND` = 70µs total.
+
+Slot formula (uniform across all profiles):
+
+```
+ARR = one_pulse + zero_pulse + guard_band
+```
+
+| Profile    | `one` | `zero` | `guard` | `parasite guard` | `short≤` | Slot  |
+|------------|------:|-------:|--------:|-----------------:|---------:|------:|
+| FAST       | 5µs  | 60µs  | 3µs    | 50µs            | 10µs    | 68µs |
+| STANDARD   | 5µs  | 60µs  | 5µs    | 100µs           | 10µs    | 70µs |
+| SLOW       | 8µs  | 90µs  | 20µs   | 200µs           | 15µs    | 118µs|
+| ROBUST     | 10µs | 110µs | 30µs   | 250µs           | 18µs    | 150µs|
+
+`parasite guard` is used in place of `guard` when parasite power is engaged
+(via `ow_set_parasite_guard()`); it widens the window so the strong-pullup
+release margin does not clip the sample. SLOW / ROBUST trade conversion
+throughput for timing margin and are intended for long wiring, parasite buses
+or electrically noisy setups.
 
 ## Troubleshooting
 

--- a/inc/onewire.h
+++ b/inc/onewire.h
@@ -53,12 +53,35 @@
  *  @note Hardware-validated at 5µs on every supported clock:
  *        STM32F030@48/8MHz, STM32F103@72/8MHz and STM32G031@64/16MHz. */
 #define ONEWIRE_ONE_PULSE 5
-/** @brief Duration of a '0' bit write pulse in microseconds */
 #define ONEWIRE_ZERO_PULSE 60
-/** @brief Guard band between slots in microseconds (bus rise time + DMA latency) */
 #define ONEWIRE_GUARD_BAND 5
-/** @brief Pulse threshold separating short ('1') from long ('0') slots in microseconds */
 #define ONEWIRE_SHORT_PULSE_MAX 10
+
+typedef enum {
+    ONEWIRE_TIMING_FAST = 0,
+    ONEWIRE_TIMING_STANDARD,
+    ONEWIRE_TIMING_SLOW,
+    ONEWIRE_TIMING_ROBUST,
+    ONEWIRE_TIMING_COUNT
+} onewire_timing_profile_t;
+
+typedef struct {
+    uint8_t one_pulse;
+    uint8_t zero_pulse;
+    uint8_t guard_band;
+    uint8_t parasite_guard_band;
+    uint8_t short_pulse_max;
+} onewire_timing_t;
+
+#define ONEWIRE_TIMING_PROFILE_DEFAULT ONEWIRE_TIMING_STANDARD
+
+extern uint8_t ow_one_pulse_us;
+extern uint8_t ow_zero_pulse_us;
+extern uint8_t ow_guard_band_us;
+extern uint8_t ow_short_pulse_max_us;
+void ow_set_parasite_guard(uint8_t parasite);
+void onewire_set_timing_profile(onewire_timing_profile_t profile);
+onewire_timing_profile_t onewire_get_timing_profile(void);
 
 /** @} */
 
@@ -164,7 +187,7 @@ void onewire_read_data(volatile uint8_t* dst, uint8_t bytes);
  * @note A pulse duration `<= ONEWIRE_SHORT_PULSE_MAX` is the short ('1') slot.
  */
 static inline uint8_t onewire_bit_from_pulse(uint16_t dur) {
-    return (dur <= ONEWIRE_SHORT_PULSE_MAX) ? 1u : 0u;
+    return (dur <= ow_short_pulse_max_us) ? 1u : 0u;
 }
 
 /**

--- a/inc/ow_stats.h
+++ b/inc/ow_stats.h
@@ -11,7 +11,9 @@
  * The dump is non-blocking: ow_stats_dump_start() initiates it,
  * ow_stats_dump_poll() outputs a few bytes per main-loop call.
  *
- * @note RAM cost: ~180 bytes (8 sensors × 18 + 16 histogram buckets × 2 + 5).
+ * @note RAM cost: ~290 bytes (8 sensors × 26 B + 16-entry uint32_t histogram
+ *       [64 B] + cycle/error counters; 13 of the 16 histogram buckets, indices
+ *       0–12, are populated).
  */
 
 #ifndef OW_STATS_H

--- a/port/stm32f0/ow_port_f0.h
+++ b/port/stm32f0/ow_port_f0.h
@@ -140,9 +140,9 @@ __STATIC_FORCEINLINE void ow_port_capture(volatile void* dst, uint16_t count, ui
  */
 __STATIC_FORCEINLINE void ow_port_feed(const uint8_t* cmd, uint16_t slots) {
     T1.RCR = slots - 1;
-    T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND;
+    T1.ARR = ow_one_pulse_us + ow_zero_pulse_us + ow_guard_band_us;
     T1.CCR3 = cmd[0];
-    T1.CCR2 = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE;
+    T1.CCR2 = ow_one_pulse_us + ow_zero_pulse_us;
     T1.CCMR2 = TIM_CCMR2(OC3M_0, OC3M_1, OC3M_2);
     T1.CCER = TIM_CCER(CC3E);
     T1.DIER = TIM_DIER(CC2DE);
@@ -194,7 +194,7 @@ __STATIC_FORCEINLINE void ow_port_write_slots(const uint8_t* pulses, uint16_t sl
     if (slots == 1) {
         /* Single slot: no DMA needed, avoids a zero-length DMA transaction */
         T1.RCR = 0; /* Single slot, no repetition */
-        T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND; /* Total bit slot time */
+        T1.ARR = ow_one_pulse_us + ow_zero_pulse_us + ow_guard_band_us; /* Total bit slot time */
         T1.CCR3 = pulses[0]; /* Pulse duration encodes the bit */
         /* OC3PE plus a preload zero release the bus at the terminal update
          * event, exactly when the one-pulse timer stops (hardware bus release). */
@@ -215,8 +215,8 @@ __STATIC_FORCEINLINE void ow_port_write_slots(const uint8_t* pulses, uint16_t sl
  */
 __STATIC_FORCEINLINE void ow_port_read_pair(volatile uint16_t* edge_out) {
     T1.RCR = 1; /* Two read slots, then a single update event */
-    T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND; /* Total bit slot time */
-    T1.CCR3 = ONEWIRE_ONE_PULSE; /* Read pulse duration */
+    T1.ARR = ow_one_pulse_us + ow_zero_pulse_us + ow_guard_band_us; /* Total bit slot time */
+    T1.CCR3 = ow_one_pulse_us; /* Read pulse duration */
     T1.CCMR2 = TIM_CCMR2(OC3M_0, OC3M_1, OC3M_2, OC3PE, CC4S_1, OW_PORT_IC4F_ARGS);
     T1.CCER = TIM_CCER(CC3E, CC4E);
     T1.DIER = TIM_DIER(CC4DE);
@@ -238,9 +238,9 @@ __STATIC_FORCEINLINE void ow_port_read_pair(volatile uint16_t* edge_out) {
  */
 __STATIC_FORCEINLINE void ow_port_write_then_read(uint8_t bit, volatile uint16_t* edge3,
                                                   const uint8_t* read_pulse) {
-    const uint8_t write_pulse = bit ? (uint8_t)ONEWIRE_ONE_PULSE : (uint8_t)ONEWIRE_ZERO_PULSE;
+    const uint8_t write_pulse = bit ? ow_one_pulse_us : ow_zero_pulse_us;
     T1.RCR = 2; /* Three slots, then a single update event */
-    T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND; /* Total bit slot time */
+    T1.ARR = ow_one_pulse_us + ow_zero_pulse_us + ow_guard_band_us; /* Total bit slot time */
     /* Arm the direction pulse first. The bus was released idle-high by
      * ow_port_bus_done(), so this write produces the single clean falling edge
      * the devices re-sync their slot timer to. Holding it from the top instead
@@ -248,7 +248,7 @@ __STATIC_FORCEINLINE void ow_port_write_then_read(uint8_t bit, volatile uint16_t
      * bus is low, so the open-drain RC rise can never be mistaken for a slot
      * edge. */
     T1.CCR3 = write_pulse; /* Slot 1 write pulse encodes the direction bit */
-    T1.CCR2 = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE; /* End-of-slot reload trigger */
+    T1.CCR2 = ow_one_pulse_us + ow_zero_pulse_us; /* End-of-slot reload trigger */
     /* OC3 in PWM mode (no preload so the reload is immediate), CC4 capture armed */
     T1.CCMR2 = TIM_CCMR2(OC3M_0, OC3M_1, OC3M_2, CC4S_1, OW_PORT_IC4F_ARGS);
     T1.CCER = TIM_CCER(CC3E, CC4E); /* Enable both channels */
@@ -287,8 +287,8 @@ __STATIC_FORCEINLINE void ow_port_write_then_read(uint8_t bit, volatile uint16_t
 __STATIC_FORCEINLINE void ow_port_read_data(volatile uint8_t* dst, uint8_t bytes) {
     const uint16_t bits = (uint16_t)bytes * ONEWIRE_BITS_PER_BYTE;
     T1.RCR = bits - 1;
-    T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND;
-    T1.CCR3 = ONEWIRE_ONE_PULSE;
+    T1.ARR = ow_one_pulse_us + ow_zero_pulse_us + ow_guard_band_us;
+    T1.CCR3 = ow_one_pulse_us;
     ow_port_capture((volatile void*)dst, bits, 8);
 }
 

--- a/port/stm32f1/ow_port_f1.h
+++ b/port/stm32f1/ow_port_f1.h
@@ -136,9 +136,9 @@ __STATIC_FORCEINLINE void ow_port_capture(volatile void* dst, uint16_t count, ui
  */
 __STATIC_FORCEINLINE void ow_port_feed(const uint8_t* cmd, uint16_t slots) {
     T1.RCR = slots - 1;
-    T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND;
+    T1.ARR = ow_one_pulse_us + ow_zero_pulse_us + ow_guard_band_us;
     T1.CCR3 = cmd[0];
-    T1.CCR2 = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE;
+    T1.CCR2 = ow_one_pulse_us + ow_zero_pulse_us;
     T1.CCMR2 = TIM_CCMR2(OC3M_0, OC3M_1, OC3M_2);
     T1.CCER = TIM_CCER(CC3E);
     T1.DIER = TIM_DIER(CC2DE);
@@ -190,7 +190,7 @@ __STATIC_FORCEINLINE void ow_port_write_slots(const uint8_t* pulses, uint16_t sl
     if (slots == 1) {
         /* Single slot: no DMA needed, avoids a zero-length DMA transaction */
         T1.RCR = 0; /* Single slot, no repetition */
-        T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND; /* Total bit slot time */
+        T1.ARR = ow_one_pulse_us + ow_zero_pulse_us + ow_guard_band_us; /* Total bit slot time */
         T1.CCR3 = pulses[0]; /* Pulse duration encodes the bit */
         /* OC3PE plus a preload zero release the bus at the terminal update
          * event, exactly when the one-pulse timer stops (hardware bus release). */
@@ -211,8 +211,8 @@ __STATIC_FORCEINLINE void ow_port_write_slots(const uint8_t* pulses, uint16_t sl
  */
 __STATIC_FORCEINLINE void ow_port_read_pair(volatile uint16_t* edge_out) {
     T1.RCR = 1; /* Two read slots, then a single update event */
-    T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND; /* Total bit slot time */
-    T1.CCR3 = ONEWIRE_ONE_PULSE; /* Read pulse duration */
+    T1.ARR = ow_one_pulse_us + ow_zero_pulse_us + ow_guard_band_us; /* Total bit slot time */
+    T1.CCR3 = ow_one_pulse_us; /* Read pulse duration */
     T1.CCMR2 = TIM_CCMR2(OC3M_0, OC3M_1, OC3M_2, OC3PE, CC4S_1, OW_PORT_IC4F_ARGS);
     T1.CCER = TIM_CCER(CC3E, CC4E);
     T1.DIER = TIM_DIER(CC4DE);
@@ -234,9 +234,9 @@ __STATIC_FORCEINLINE void ow_port_read_pair(volatile uint16_t* edge_out) {
  */
 __STATIC_FORCEINLINE void ow_port_write_then_read(uint8_t bit, volatile uint16_t* edge3,
                                                   const uint8_t* read_pulse) {
-    const uint8_t write_pulse = bit ? (uint8_t)ONEWIRE_ONE_PULSE : (uint8_t)ONEWIRE_ZERO_PULSE;
+    const uint8_t write_pulse = bit ? ow_one_pulse_us : ow_zero_pulse_us;
     T1.RCR = 2; /* Three slots, then a single update event */
-    T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND; /* Total bit slot time */
+    T1.ARR = ow_one_pulse_us + ow_zero_pulse_us + ow_guard_band_us; /* Total bit slot time */
     /* Arm the direction pulse first. The bus was released idle-high by
      * ow_port_bus_done(), so this write produces the single clean falling edge
      * the devices re-sync their slot timer to. Holding it from the top instead
@@ -244,7 +244,7 @@ __STATIC_FORCEINLINE void ow_port_write_then_read(uint8_t bit, volatile uint16_t
      * bus is low, so the open-drain RC rise can never be mistaken for a slot
      * edge. */
     T1.CCR3 = write_pulse; /* Slot 1 write pulse encodes the direction bit */
-    T1.CCR2 = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE; /* End-of-slot reload trigger */
+    T1.CCR2 = ow_one_pulse_us + ow_zero_pulse_us; /* End-of-slot reload trigger */
     /* OC3 in PWM mode (no preload so the reload is immediate), CC4 capture armed */
     T1.CCMR2 = TIM_CCMR2(OC3M_0, OC3M_1, OC3M_2, CC4S_1, OW_PORT_IC4F_ARGS);
     T1.CCER = TIM_CCER(CC3E, CC4E); /* Enable both channels */
@@ -283,8 +283,8 @@ __STATIC_FORCEINLINE void ow_port_write_then_read(uint8_t bit, volatile uint16_t
 __STATIC_FORCEINLINE void ow_port_read_data(volatile uint8_t* dst, uint8_t bytes) {
     const uint16_t bits = (uint16_t)bytes * ONEWIRE_BITS_PER_BYTE;
     T1.RCR = bits - 1;
-    T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND;
-    T1.CCR3 = ONEWIRE_ONE_PULSE;
+    T1.ARR = ow_one_pulse_us + ow_zero_pulse_us + ow_guard_band_us;
+    T1.CCR3 = ow_one_pulse_us;
     ow_port_capture((volatile void*)dst, bits, 8);
 }
 

--- a/port/stm32g0/ow_port_g0.h
+++ b/port/stm32g0/ow_port_g0.h
@@ -172,9 +172,9 @@ __STATIC_FORCEINLINE void ow_port_capture(volatile void* dst, uint16_t count, ui
  */
 __STATIC_FORCEINLINE void ow_port_feed(const uint8_t* cmd, uint16_t slots) {
     T1.RCR = slots - 1;
-    T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND;
+    T1.ARR = ow_one_pulse_us + ow_zero_pulse_us + ow_guard_band_us;
     T1.CCR3 = cmd[0];
-    T1.CCR2 = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE;
+    T1.CCR2 = ow_one_pulse_us + ow_zero_pulse_us;
     T1.CCMR2 = TIM_CCMR2(OC3M_0, OC3M_1, OC3M_2);
     T1.CCER = TIM_CCER(CC3E);
     T1.DIER = TIM_DIER(CC2DE);
@@ -227,7 +227,7 @@ __STATIC_FORCEINLINE void ow_port_write_slots(const uint8_t* pulses, uint16_t sl
     if (slots == 1) {
         /* Single slot: no DMA needed, avoids a zero-length DMA transaction */
         T1.RCR = 0; /* Single slot, no repetition */
-        T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND; /* Total bit slot time */
+        T1.ARR = ow_one_pulse_us + ow_zero_pulse_us + ow_guard_band_us; /* Total bit slot time */
         T1.CCR3 = pulses[0]; /* Pulse duration encodes the bit */
         /* OC3PE plus a preload zero release the bus at the terminal update
          * event, exactly when the one-pulse timer stops (hardware bus release). */
@@ -248,8 +248,8 @@ __STATIC_FORCEINLINE void ow_port_write_slots(const uint8_t* pulses, uint16_t sl
  */
 __STATIC_FORCEINLINE void ow_port_read_pair(volatile uint16_t* edge_out) {
     T1.RCR = 1; /* Two read slots, then a single update event */
-    T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND; /* Total bit slot time */
-    T1.CCR3 = ONEWIRE_ONE_PULSE; /* Read pulse duration */
+    T1.ARR = ow_one_pulse_us + ow_zero_pulse_us + ow_guard_band_us; /* Total bit slot time */
+    T1.CCR3 = ow_one_pulse_us; /* Read pulse duration */
     T1.CCMR2 = TIM_CCMR2(OC3M_0, OC3M_1, OC3M_2, OC3PE, CC4S_1, OW_PORT_IC4F_ARGS);
     T1.CCER = TIM_CCER(CC3E, CC4E);
     T1.DIER = TIM_DIER(CC4DE);
@@ -272,9 +272,9 @@ __STATIC_FORCEINLINE void ow_port_read_pair(volatile uint16_t* edge_out) {
  */
 __STATIC_FORCEINLINE void ow_port_write_then_read(uint8_t bit, volatile uint16_t* edge3,
                                                   const uint8_t* read_pulse) {
-    const uint8_t write_pulse = bit ? (uint8_t)ONEWIRE_ONE_PULSE : (uint8_t)ONEWIRE_ZERO_PULSE;
+    const uint8_t write_pulse = bit ? ow_one_pulse_us : ow_zero_pulse_us;
     T1.RCR = 2; /* Three slots, then a single update event */
-    T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND; /* Total bit slot time */
+    T1.ARR = ow_one_pulse_us + ow_zero_pulse_us + ow_guard_band_us; /* Total bit slot time */
     /* Arm the direction pulse first. The bus was released idle-high by
      * ow_port_bus_done(), so this write produces the single clean falling edge
      * the devices re-sync their slot timer to. Holding it from the top instead
@@ -282,7 +282,7 @@ __STATIC_FORCEINLINE void ow_port_write_then_read(uint8_t bit, volatile uint16_t
      * bus is low, so the open-drain RC rise can never be mistaken for a slot
      * edge. */
     T1.CCR3 = write_pulse; /* Slot 1 write pulse encodes the direction bit */
-    T1.CCR2 = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE; /* End-of-slot reload trigger */
+    T1.CCR2 = ow_one_pulse_us + ow_zero_pulse_us; /* End-of-slot reload trigger */
     /* OC3 in PWM mode (no preload so the reload is immediate), CC4 capture armed */
     T1.CCMR2 = TIM_CCMR2(OC3M_0, OC3M_1, OC3M_2, CC4S_1, OW_PORT_IC4F_ARGS);
     T1.CCER = TIM_CCER(CC3E, CC4E); /* Enable both channels */
@@ -323,8 +323,8 @@ __STATIC_FORCEINLINE void ow_port_write_then_read(uint8_t bit, volatile uint16_t
 __STATIC_FORCEINLINE void ow_port_read_data(volatile uint8_t* dst, uint8_t bytes) {
     const uint16_t bits = (uint16_t)bytes * ONEWIRE_BITS_PER_BYTE;
     T1.RCR = bits - 1;
-    T1.ARR = ONEWIRE_ONE_PULSE + ONEWIRE_ZERO_PULSE + ONEWIRE_GUARD_BAND;
-    T1.CCR3 = ONEWIRE_ONE_PULSE;
+    T1.ARR = ow_one_pulse_us + ow_zero_pulse_us + ow_guard_band_us;
+    T1.CCR3 = ow_one_pulse_us;
     ow_port_capture((volatile void*)dst, bits, 8);
 }
 

--- a/src/demo1.c
+++ b/src/demo1.c
@@ -1,0 +1,96 @@
+#include "app.h"
+#include "ds18b20.h"
+
+#ifndef DS18B20_SEARCH_MAX_DEVICES
+#define DS18B20_SEARCH_MAX_DEVICES 8u
+#endif
+
+static uint8_t found_roms[DS18B20_SEARCH_MAX_DEVICES][8];
+static uint8_t found_count = 0;
+static uint8_t select_index = 0;
+static uint8_t search_running = 1;
+
+static uint8_t device_found_sink(const uint8_t* rom) {
+    for (uint8_t i = 0; i < DS18B20_ROM_BYTES; i++) {
+        found_roms[found_count][i] = rom[i];
+    }
+    found_count++;
+    uart_write_str("  ROM: ");
+    for (uint8_t i = 0; i < DS18B20_ROM_BYTES; i++) {
+        uart_write_hex(rom[i]);
+        if (i != DS18B20_ROM_BYTES - 1) uart_tx_enqueue_byte(' ');
+    }
+    uart_write_str("\r\n");
+    return 0;
+}
+
+static void report_search_result(void) {
+    if (found_count == 0) {
+        uart_write_str("No devices on the 1-Wire bus.\r\n");
+    } else {
+        uart_write_str("Found ");
+        uart_write_int(found_count);
+        uart_write_str(" device(s). Measuring each in turn.\r\n");
+        select_index = 0;
+        ds18b20_select(found_roms[select_index]);
+    }
+}
+
+void ds18b20_complete(int16_t temp) {
+    for (uint8_t i = 0; i < DS18B20_ROM_BYTES; i++) {
+        uart_write_hex(found_roms[select_index][i]);
+        if (i != DS18B20_ROM_BYTES - 1) uart_tx_enqueue_byte(' ');
+    }
+    uart_write_str(": ");
+    if (temp == DS18B20_TEMP_ERROR_NO_SENSOR) {
+        uart_write_str("no sensor detected.");
+    } else if (temp == DS18B20_TEMP_ERROR_CRC_FAIL) {
+        uart_write_str("CRC check failed.");
+    } else if (temp == DS18B20_TEMP_ERROR_GENERIC) {
+        uart_write_str("generic failure.");
+    } else {
+        int whole = temp / 10;
+        int frac = temp % 10;
+        if (frac < 0) frac = -frac;
+        if (whole == 0 && temp < 0) {
+            uart_write_str("-0");
+        } else {
+            uart_write_int(whole);
+        }
+        uart_write_str(".");
+        uart_write_int(frac);
+        uart_write_str(" C");
+    }
+    uart_write_str("\r\n");
+
+    if (found_count > 1) {
+        select_index = (uint8_t)((select_index + 1u) % found_count);
+        ds18b20_select(found_roms[select_index]);
+        if (select_index == 0) {
+            uart_write_str("--------------------------------\r\n");
+        }
+    }
+}
+
+int main(void) {
+    app_init();
+    uart_write_str("DS18B20 demo1 starting...\r\n");
+    uart_write_str("Searching 1-Wire bus...\r\n");
+    ds18b20_init();
+#if defined(PARASITE_POWER)
+    ds18b20_set_parasite(1);
+#endif
+    ds18b20_search_start(device_found_sink, DS18B20_SEARCH_MAX_DEVICES);
+
+    for (;;) {
+        if (search_running) {
+            if (ds18b20_search_poll()) {
+                search_running = 0;
+                report_search_result();
+            }
+        } else {
+            ds18b20_poll();
+        }
+        uart_poll_tx();
+    }
+}

--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -13,12 +13,7 @@
  * @{
  */
 
-/** @brief Duration of '1' bit pulse in microseconds (from the 1-Wire layer) */
-#define ONE_PULSE ONEWIRE_ONE_PULSE
-/** @brief Duration of '0' bit pulse in microseconds (from the 1-Wire layer) */
-#define ZERO_PULSE ONEWIRE_ZERO_PULSE
-/** @brief Guard band between slots to prevent overlap due to bus rise time and DMA latency */
-#define GUARD_BAND ONEWIRE_GUARD_BAND
+
 /** @brief Total length of DS18B20 scratchpad in bytes */
 #define DS18B20_SCRATCHPAD_LEN 9
 /** @brief Number of bytes to include in the scratchpad CRC calculation */
@@ -64,28 +59,6 @@
 /** @brief Wait for Copy Scratchpad (t_COPY) / Recall EEPROM (t_RECALL)
  *         completion in microseconds (DS18B20 datasheet: 10ms max). */
 #define DS18B20_EEPROM_WAIT_US 10000
-
-/**
- * @brief Convert byte bit to pulse duration (ONE_PULSE µs for '1', ZERO_PULSE µs for '0')
- * @param B Byte value
- * @param N Bit position (0-7)
- * @return Pulse duration in microseconds
- */
-#define B2P(B, N) (((B) & (1 << (N))) ? ONE_PULSE : ZERO_PULSE)
-
-/**
- * @brief Convert entire byte to sequence of pulse durations for transmission
- * @param B Byte value to convert
- */
-#define BYTE_TO_PULSES(B)                       \
-    B2P(B, 0), B2P(B, 1), B2P(B, 2), B2P(B, 3), \
-        B2P(B, 4), B2P(B, 5), B2P(B, 6), B2P(B, 7)
-
-/** @brief DS18B20 Convert T command sequence in pulse duration format */
-static const uint8_t conv_cmd[] = {BYTE_TO_PULSES(0xCC), BYTE_TO_PULSES(0x44), 0};
-
-/** @brief DS18B20 Read Scratchpad command sequence in pulse duration format */
-static const uint8_t read_cmd[] = {BYTE_TO_PULSES(0xCC), BYTE_TO_PULSES(0xBE), 0};
 
 /**
  * @}
@@ -861,6 +834,9 @@ static uint8_t txn_poll(void) {
             txn_ctx.phase = DS18B20_TXN_DONE;
             break;
         }
+        if (ctx.parasite) {
+            onewire_strong_pullup(1);
+        }
         onewire_write_slots(txn_ctx.pulses, txn_ctx.slots);
         txn_ctx.phase = DS18B20_TXN_WRITE;
         break;
@@ -869,6 +845,9 @@ static uint8_t txn_poll(void) {
         // Command write completed: read the response back if the command has
         // one, otherwise wait the required hold-off or finish immediately.
         if (txn_ctx.read_bytes) {
+            if (ctx.parasite) {
+                onewire_strong_pullup(0);
+            }
             onewire_read_data(ctx.pulse, txn_ctx.read_bytes);
             txn_ctx.phase = DS18B20_TXN_READ;
         } else if (txn_ctx.wait_us) {
@@ -881,6 +860,9 @@ static uint8_t txn_poll(void) {
             onewire_start_timer(txn_ctx.wait_us, 0);
             txn_ctx.phase = DS18B20_TXN_WAIT;
         } else {
+            if (ctx.parasite) {
+                onewire_strong_pullup(0);
+            }
             txn_ctx.ok = 1;
             txn_ctx.phase = DS18B20_TXN_DONE;
         }
@@ -942,6 +924,7 @@ static void txn_start(uint8_t command, uint8_t* out, const uint8_t* payload,
     txn_ctx.ok = 0;
     txn_ctx.finished = 0;
     txn_build_pulses(); // Pre-build the command for the current address mode
+    onewire_strong_pullup(0);
     txn_ctx.phase = DS18B20_TXN_RESET;
     onewire_reset(ctx.edge); // Schedule the first hardware operation
 }
@@ -1100,7 +1083,7 @@ uint8_t ds18b20_last_command_ok(void) { return txn_ctx.ok; }
  *       ds18b20_detect_parasite() reports the wiring and stores it back into
  *       this flag on success; this setter tells the driver how to behave.
  */
-void ds18b20_set_parasite(uint8_t parasite) { ctx.parasite = parasite ? 1u : 0u; }
+void ds18b20_set_parasite(uint8_t parasite) { ctx.parasite = parasite ? 1u : 0u; ow_set_parasite_guard(ctx.parasite); }
 
 /**
  * @brief Current parasite-power configuration of the driver
@@ -1123,6 +1106,7 @@ uint8_t ds18b20_detect_parasite_poll(void) {
     if (txn_ctx.ok) {
         // The sensor drives one bit: 0 = parasite power, 1 = external power.
         ctx.parasite = (txn_ctx.raw[0] & 0x01) ? 0u : 1u;
+        ow_set_parasite_guard(ctx.parasite);
     }
     return 1;
 }
@@ -1217,7 +1201,16 @@ void ds18b20_select(const uint8_t* rom) {
  * @param[in] skip_tbl Skip-ROM command table (for broadcast mode)
  * @param[in] next_state State to transition to on success
  */
-static void issue_command(uint8_t cmd_byte, const uint8_t* skip_tbl, ds18b20_state_t next_state) {
+static uint8_t conv_cmd[DS18B20_DMA_TRANSFERS + 1];
+static uint8_t read_cmd[DS18B20_DMA_TRANSFERS + 1];
+
+static void build_skip_cmd(uint8_t* dst, uint8_t cmd_byte) {
+    onewire_encode_byte(dst, 0xCC);
+    onewire_encode_byte(dst + 8, cmd_byte);
+    dst[DS18B20_DMA_TRANSFERS] = 0;
+}
+
+static void issue_command(uint8_t cmd_byte, ds18b20_state_t next_state) {
     if (!onewire_present(ctx.edge)) {
         // Return to IDLE before the callback so a re-selection from inside
         // ds18b20_complete() is accepted (ds18b20_select() only acts at IDLE).
@@ -1237,6 +1230,8 @@ static void issue_command(uint8_t cmd_byte, const uint8_t* skip_tbl, ds18b20_sta
         build_addr_cmd(cmd_byte);
         onewire_write_slots(ctx.addr_cmd, DS18B20_MATCH_SLOTS);
     } else {
+        uint8_t* skip_tbl = (cmd_byte == DS18B20_CONVERT_T) ? conv_cmd : read_cmd;
+        build_skip_cmd(skip_tbl, cmd_byte);
         onewire_write_slots(skip_tbl, DS18B20_DMA_TRANSFERS);
     }
     ctx.current_state = next_state;
@@ -1297,7 +1292,7 @@ void ds18b20_poll(void) {
         if (ctx.parasite) {
             onewire_strong_pullup(1);
         }
-        issue_command(DS18B20_CONVERT_T, conv_cmd, DS18B20_ST_WAIT);
+        issue_command(DS18B20_CONVERT_T, DS18B20_ST_WAIT);
         break;
 
     case DS18B20_ST_WAIT:
@@ -1332,13 +1327,17 @@ void ds18b20_poll(void) {
             build_addr_prefix();
             ctx.address_mode = 1;
         }
-        issue_command(DS18B20_READ_SCRATCHPAD, read_cmd, DS18B20_ST_READ);
+        if (ctx.parasite) {
+            onewire_strong_pullup(1);
+        }
+        issue_command(DS18B20_READ_SCRATCHPAD, DS18B20_ST_READ);
         break;
 
     case DS18B20_ST_READ:
-        // Initiate scratchpad data read using timer capture and DMA
+        if (ctx.parasite) {
+            onewire_strong_pullup(0);
+        }
         onewire_read_data(ctx.pulse, DS18B20_SCRATCHPAD_LEN);
-        // Transition to DECODE state
         ctx.current_state = DS18B20_ST_DECODE;
         break;
 

--- a/src/onewire.c
+++ b/src/onewire.c
@@ -27,6 +27,45 @@
 
 /** @} */
 
+static const onewire_timing_t timing_profiles[ONEWIRE_TIMING_COUNT] = {
+    [ONEWIRE_TIMING_FAST]     = { 5,  60,  3,  50,  10 },
+    [ONEWIRE_TIMING_STANDARD] = { 5,  60,  5, 100, 10 },
+    [ONEWIRE_TIMING_SLOW]     = { 8,  90, 20, 200, 15 },
+    [ONEWIRE_TIMING_ROBUST]   = { 10, 110, 30, 250, 18 },
+};
+
+static onewire_timing_profile_t ow_profile = ONEWIRE_TIMING_PROFILE_DEFAULT;
+static uint8_t ow_parasite_flag = 0;
+uint8_t ow_one_pulse_us = ONEWIRE_ONE_PULSE;
+uint8_t ow_zero_pulse_us = ONEWIRE_ZERO_PULSE;
+uint8_t ow_guard_band_us = ONEWIRE_GUARD_BAND;
+uint8_t ow_short_pulse_max_us = ONEWIRE_SHORT_PULSE_MAX;
+static uint8_t search_read_pulse[3];
+
+void ow_set_parasite_guard(uint8_t parasite) {
+    ow_parasite_flag = parasite ? 1u : 0u;
+    ow_guard_band_us = ow_parasite_flag ? timing_profiles[ow_profile].parasite_guard_band
+                                       : timing_profiles[ow_profile].guard_band;
+}
+
+void onewire_set_timing_profile(onewire_timing_profile_t profile) {
+    if (profile >= ONEWIRE_TIMING_COUNT) {
+        return;
+    }
+    ow_profile = profile;
+    ow_one_pulse_us = timing_profiles[profile].one_pulse;
+    ow_zero_pulse_us = timing_profiles[profile].zero_pulse;
+    ow_short_pulse_max_us = timing_profiles[profile].short_pulse_max;
+    search_read_pulse[0] = ow_one_pulse_us;
+    search_read_pulse[1] = ow_one_pulse_us;
+    search_read_pulse[2] = 0;
+    ow_set_parasite_guard(ow_parasite_flag);
+}
+
+onewire_timing_profile_t onewire_get_timing_profile(void) {
+    return ow_profile;
+}
+
 /**
  * @defgroup ONEWIRE_Private_Variables ONEWIRE Private Variables
  * @{
@@ -43,7 +82,7 @@ static volatile uint16_t search_edge3[3];
  *        event and kicks read slots 2-3, entry 1 re-arms the slot-3 kick, and
  *        the trailing 0 is written during slot 3 so the one-pulse timer stops
  *        with the line released to idle HIGH (hardware bus release). */
-static const uint8_t search_read_pulse[3] = {ONEWIRE_ONE_PULSE, ONEWIRE_ONE_PULSE, 0};
+
 
 /** @brief Edge capture buffer used by the search engine for bus resets and
  *         plain id/cmp pair reads (the merged write+read uses search_edge3). */
@@ -107,6 +146,7 @@ void onewire_init(void) {
     search_ctx.finished = 1;
     // Enable clocks, configure the timer prescaler, bus pin AF open-drain.
     ow_port_init();
+    onewire_set_timing_profile(ONEWIRE_TIMING_PROFILE_DEFAULT);
 }
 
 uint8_t onewire_bus_done(void) {
@@ -139,7 +179,7 @@ void onewire_write_slots(const uint8_t* pulses, uint16_t slots) {
 }
 
 void onewire_write_bit(uint8_t bit) {
-    uint8_t pulse = bit ? (uint8_t)ONEWIRE_ONE_PULSE : (uint8_t)ONEWIRE_ZERO_PULSE;
+    uint8_t pulse = bit ? ow_one_pulse_us : ow_zero_pulse_us;
     onewire_write_slots(&pulse, 1);
 }
 
@@ -172,7 +212,7 @@ void onewire_decode_pulses(uint8_t* dst, const volatile uint8_t* pulse, uint8_t 
 
 void onewire_encode_byte(uint8_t* out, uint8_t byte) {
     for (uint8_t i = 0; i < ONEWIRE_BITS_PER_BYTE; i++) {
-        out[i] = (byte & (1u << i)) ? (uint8_t)ONEWIRE_ONE_PULSE : (uint8_t)ONEWIRE_ZERO_PULSE;
+        out[i] = (byte & (1u << i)) ? ow_one_pulse_us : ow_zero_pulse_us;
     }
 }
 

--- a/tests/test/test_alarm_search.c
+++ b/tests/test/test_alarm_search.c
@@ -15,8 +15,9 @@
 #include "unity.h"
 #include <string.h>
 
-#define ONE 5u
-#define ZERO 60u
+#include "onewire.h"
+#define ONE ow_one_pulse_us
+#define ZERO ow_zero_pulse_us
 
 static uint8_t g_rom[8];
 static uint8_t g_found_roms[4][8];
@@ -135,7 +136,9 @@ void test_alarm_search_finds_device_sends_0xEC(void) {
                 const hw_ccr1_feed_log_t* log = hw_ccr1_feed_log();
                 if (log->count == 8) { /* the 0xEC command feed */
                     ec_feed_checked = 1;
-                    static const uint16_t expected[8] = {ZERO, ONE, ONE, ZERO, ONE, ONE, ONE, 0};
+                    uint16_t expected[8];
+                    expected[0] = ZERO; expected[1] = ONE; expected[2] = ONE; expected[3] = ZERO;
+                    expected[4] = ONE; expected[5] = ONE; expected[6] = ONE; expected[7] = 0;
                     for (uint8_t i = 0; i < 8; i++) {
                         TEST_ASSERT_EQUAL_UINT16(expected[i], log->values[i]);
                     }

--- a/tests/test/test_alarm_thresholds.c
+++ b/tests/test/test_alarm_thresholds.c
@@ -21,8 +21,9 @@
 #include "unity.h"
 #include <string.h>
 
-#define ONE 5u
-#define ZERO 60u
+#include "onewire.h"
+#define ONE ow_one_pulse_us
+#define ZERO ow_zero_pulse_us
 
 /*-------------------------------------------------------------
  *  Shared helpers

--- a/tests/test/test_app_uart.c
+++ b/tests/test/test_app_uart.c
@@ -1,0 +1,107 @@
+/* ============================================================
+ *  test_app_uart.c - Application-layer UART TX ring buffer
+ *
+ *  Only the non-blocking ring buffer (uart_tx_enqueue_byte / uart_poll_tx /
+ *  uart_flush / uart_write_str / uart_write_int / uart_write_hex) is compiled
+ *  into the host test build; the hardware bring-up half of app.c is excluded
+ *  by DS18B20_TEST_HARNESS.  These tests exercise that surface through the
+ *  mocked USART1 peripheral.
+ * ============================================================ */
+
+#include "app.h"
+#if defined(OW_PORT_TARGET_F0)
+#include "stm32f0xx.h"
+#elif defined(OW_PORT_TARGET_G0)
+#include "stm32g0xx.h"
+#else
+#include "stm32f1xx.h"
+#endif
+#include "hw_model.h"
+#include "unity.h"
+
+#if defined(OW_PORT_TARGET_G0)
+  #define TXE_BIT  USART_ISR_TXE_TXFNF
+  #define TX_SR    ISR
+  #define TX_DR    TDR
+#elif defined(OW_PORT_TARGET_F0)
+  #define TXE_BIT  USART_ISR_TXE
+  #define TX_SR    ISR
+  #define TX_DR    TDR
+#else /* F1 */
+  #define TXE_BIT  USART_SR_TXE
+  #define TX_SR    SR
+  #define TX_DR    DR
+#endif
+
+/* Drain any bytes left in the static ring buffer from earlier tests. */
+static void uart_drain(void) {
+    mock_usart1.TX_SR |= TXE_BIT;
+    uart_flush();
+}
+
+/* Pop one enqueued byte (drives the mocked USART TX data register). */
+static uint8_t uart_pop(void) {
+    mock_usart1.TX_SR |= TXE_BIT;
+    uart_poll_tx();
+    return (uint8_t)mock_usart1.TX_DR;
+}
+
+static void expect_str(const char* s) {
+    for (const char* p = s; *p; p++) {
+        TEST_ASSERT_EQUAL_UINT8((uint8_t)*p, uart_pop());
+    }
+}
+
+void test_uart_write_str_transmits(void) {
+    uart_drain();
+    TEST_ASSERT_EQUAL_INT(2, uart_write_str("Hi"));
+    expect_str("Hi");
+}
+
+void test_uart_write_int_zero_and_negative(void) {
+    uart_drain();
+    TEST_ASSERT_EQUAL_INT(1, uart_write_int(0));
+    expect_str("0");
+
+    uart_drain();
+    TEST_ASSERT_EQUAL_INT(3, uart_write_int(-42));
+    expect_str("-42");
+}
+
+void test_uart_write_int_positive(void) {
+    uart_drain();
+    TEST_ASSERT_EQUAL_INT(3, uart_write_int(123));
+    expect_str("123");
+}
+
+void test_uart_write_hex(void) {
+    uart_drain();
+    TEST_ASSERT_EQUAL_INT(2, uart_write_hex(0xA5));
+    expect_str("A5");
+}
+
+void test_uart_buffer_full_drops_byte(void) {
+    uart_drain();
+    int filled = 0;
+    while (uart_tx_enqueue_byte('X') == 1) {
+        filled++;
+    }
+    TEST_ASSERT_EQUAL_INT((int)(UART_TX_BUF_SIZE - 1u), filled);
+    /* Full buffer: extra enqueue is dropped (returns 0). */
+    TEST_ASSERT_EQUAL_INT(0, uart_tx_enqueue_byte('X'));
+
+    /* Leave exactly one free slot, then a too-long string is partially queued
+     * (uart_write_str breaks out once the buffer fills). */
+    mock_usart1.TX_SR |= TXE_BIT;
+    uart_poll_tx();
+    TEST_ASSERT_EQUAL_INT(1, uart_write_str("ZZ"));
+    uart_drain();
+}
+
+void run_test_app_uart(void) {
+    TEST_RUN(test_uart_write_str_transmits);
+    TEST_RUN(test_uart_write_int_zero_and_negative);
+    TEST_RUN(test_uart_write_int_positive);
+    TEST_RUN(test_uart_write_hex);
+    TEST_RUN(test_uart_buffer_full_drops_byte);
+}

--- a/tests/test/test_broadcast.c
+++ b/tests/test/test_broadcast.c
@@ -21,8 +21,9 @@
 #include "mock_target.h"
 #include "unity.h"
 
-#define ONE 5u
-#define ZERO 60u
+#include "onewire.h"
+#define ONE ow_one_pulse_us
+#define ZERO ow_zero_pulse_us
 
 /* Three fake device ROMs (LSB first; the driver does not re-validate them). */
 static const uint8_t k_roms[3][DS18B20_ROM_BYTES] = {

--- a/tests/test/test_bus_release.c
+++ b/tests/test/test_bus_release.c
@@ -24,8 +24,9 @@
 #include "mock_target.h"
 #include "unity.h"
 
-#define ONE 5u
-#define ZERO 60u
+#include "onewire.h"
+#define ONE ow_one_pulse_us
+#define ZERO ow_zero_pulse_us
 
 static void complete_op(uint32_t max_slots) {
     uint8_t ok = hw_run_until_uif(max_slots);

--- a/tests/test/test_eeprom.c
+++ b/tests/test/test_eeprom.c
@@ -19,8 +19,9 @@
 #include "unity.h"
 #include <string.h>
 
-#define ONE 5u
-#define ZERO 60u
+#include "onewire.h"
+#define ONE ow_one_pulse_us
+#define ZERO ow_zero_pulse_us
 
 /*-------------------------------------------------------------
  *  Shared helpers

--- a/tests/test/test_harness_api.c
+++ b/tests/test/test_harness_api.c
@@ -1,0 +1,77 @@
+/* ============================================================
+ *  test_harness_api.c - Test-support accessor smoke tests
+ *
+ *  Exercises the ds18b20_test_access / ow_stats_test_access helper
+ *  surface that is compiled into the test binary but not otherwise
+ *  reached by the functional tests, so the whole test scaffold is
+ *  covered.  These are pure accessors; the assertions only guard
+ *  against accidental signature drift.
+ * ============================================================ */
+
+#include "ds18b20.h"
+#include "ds18b20_test_access.h"
+#include "ds18b20_test_spy.h"
+#include "ow_stats.h"
+#include "ow_stats_test_access.h"
+#include "hw_model.h"
+#include "unity.h"
+
+void test_harness_accessor_smoke(void) {
+    uint8_t rom[DS18B20_ROM_BYTES] = {0x28, 1, 2, 3, 4, 5, 6, 7};
+    uint8_t out[DS18B20_ROM_BYTES];
+
+    ds18b20_test_set_selected_rom(rom);
+    ds18b20_test_get_selected_rom(out);
+    for (uint8_t i = 0; i < DS18B20_ROM_BYTES; i++) {
+        TEST_ASSERT_EQUAL_UINT8(rom[i], out[i]);
+    }
+
+    ds18b20_test_set_addr_cmd(0, 0x55);
+    TEST_ASSERT_EQUAL_UINT8(0x55, ds18b20_test_get_addr_cmd(0));
+
+    /* build_addr_prefix() derives the Match-ROM prefix from the selection. */
+    ds18b20_test_build_addr_prefix();
+
+    TEST_ASSERT_EQUAL_UINT8(0, test_ds18b20_bus_done());
+    ds18b20_test_set_search_edge3(0, 1234);
+    TEST_ASSERT_EQUAL_UINT16(1234, test_search_edge(0));
+
+    ds18b20_test_set_device_count(3);
+    TEST_ASSERT_EQUAL_UINT8(3, ds18b20_test_get_device_count());
+
+    /* Out-of-range device index must be ignored (early return). */
+    ds18b20_test_set_device(DS18B20_MAX_DEVICES, rom);
+}
+
+void test_ow_stats_accessor_bounds(void) {
+    /* Out-of-range indices return the safe defaults. */
+    TEST_ASSERT_TRUE(ow_stats_test_get_sensor(255) == NULL);
+    TEST_ASSERT_EQUAL_UINT32(0, ow_stats_test_get_histogram(255));
+    (void)ow_stats_test_get_dump_sensor();
+}
+
+/* hw_run_until_uif() has two branches not hit by the functional tests:
+ *  - timer not enabled -> returns the raw UIF status (line 142)
+ *  - requested slot count clamped below RCR+1 -> returns 0, no terminal UIF */
+void test_hw_run_until_uif_branches(void) {
+    /* Timer idle (CEN cleared by reset): returns UIF status, no DMA work. */
+    hw_reset_all();
+    TEST_ASSERT_FALSE(hw_run_until_uif(1));
+
+    /* Arm a 16-slot op (RCR=15) with CEN set, then ask for fewer slots than
+     * exist. The slot count is clamped and the loop ends without a terminal
+     * update event, exercising the clamp + early-return paths. */
+    uint8_t cmd[17];
+    for (int i = 0; i < 16; i++) {
+        cmd[i] = (i & 1u) ? 5u : 60u;
+    }
+    cmd[16] = 0;
+    test_bus_send_command_n(cmd, 16);
+    TEST_ASSERT_FALSE(hw_run_until_uif(1));
+}
+
+void run_test_harness_api(void) {
+    TEST_RUN(test_harness_accessor_smoke);
+    TEST_RUN(test_ow_stats_accessor_bounds);
+    TEST_RUN(test_hw_run_until_uif_branches);
+}

--- a/tests/test/test_main.c
+++ b/tests/test/test_main.c
@@ -49,6 +49,8 @@ extern void run_test_eeprom(void);
 extern void run_test_parasite(void);
 extern void run_test_dmamux(void);
 extern void run_test_ow_stats(void);
+extern void run_test_harness_api(void);
+extern void run_test_app_uart(void);
 
 int main(void) {
     run_test_scratchpad();
@@ -70,6 +72,8 @@ int main(void) {
     run_test_parasite();
     run_test_dmamux();
     run_test_ow_stats();
+    run_test_harness_api();
+    run_test_app_uart();
     printf("%s: %d failure(s)\n", unity_failures ? "FAIL" : "PASS", unity_failures);
     return unity_failures ? 1 : 0;
 }

--- a/tests/test/test_parasite.c
+++ b/tests/test/test_parasite.c
@@ -17,6 +17,7 @@
  * ============================================================ */
 
 #include "ds18b20.h"
+#include "onewire.h"
 #include "ds18b20_test_access.h"
 #include "ds18b20_test_spy.h"
 #include "hw_model.h"
@@ -26,8 +27,8 @@
 
 void spy_reset(void); /* defined in test_state_machine.c */
 
-#define ONE 5u
-#define ZERO 60u
+#define ONE ow_one_pulse_us
+#define ZERO ow_zero_pulse_us
 
 /*-------------------------------------------------------------
  *  Register-state helpers (per family)
@@ -401,6 +402,28 @@ void test_parasite_setter_normalises_and_init_resets(void) {
     TEST_ASSERT_TRUE(pu_idle_af_od());
 }
 
+void test_parasite_guard_band_tracks_mode(void) {
+    ow_set_parasite_guard(0);
+    ds18b20_set_parasite(0);
+    uint8_t ext = ow_guard_band_us;
+
+    /* bus in parasite mode selects the wider guard band */
+    ds18b20_set_parasite(1);
+    uint8_t para = ow_guard_band_us;
+    TEST_ASSERT_TRUE(para > ext); /* parasite guard is wider than external */
+    TEST_ASSERT_EQUAL_UINT8(para, ow_guard_band_us);
+
+    /* returning to external power restores the tighter guard */
+    ds18b20_set_parasite(0);
+    TEST_ASSERT_EQUAL_UINT8(ext, ow_guard_band_us);
+
+    /* manual override also engages the wider guard */
+    ow_set_parasite_guard(1);
+    TEST_ASSERT_EQUAL_UINT8(para, ow_guard_band_us);
+    ow_set_parasite_guard(0);
+    TEST_ASSERT_EQUAL_UINT8(ext, ow_guard_band_us);
+}
+
 /*-------------------------------------------------------------
  *  5. Auto-detect (Read Power Supply -> ctx.parasite)
  * -----------------------------------------------------------*/
@@ -493,6 +516,123 @@ void test_getter_matches_setter(void) {
 /*-------------------------------------------------------------
  *  Run all parasite-power tests
  * -----------------------------------------------------------*/
+/*-------------------------------------------------------------
+ *  Test: in parasite mode a simultaneous-conversion (scan) round
+ *  keeps the strong pull-up engaged across the inter-round pause
+ *  (scan_finish_or_next, last-device branch).
+ *----------------------------------------------------------*/
+void test_parasite_scan_engages_pullup_across_pause(void) {
+    test_spy_reset();
+    ds18b20_init();
+    ds18b20_test_reset_ctx();
+    ds18b20_test_reset_search();
+    ds18b20_test_reset_resolution();
+    ds18b20_set_parasite(1);
+
+    uint8_t rom[DS18B20_ROM_BYTES] = {0x28, 0, 0, 0, 0, 0, 0, 0};
+    ds18b20_test_set_device(0, rom);
+    ds18b20_test_set_device_count(1);
+    ds18b20_scan_start();
+    TEST_ASSERT_EQUAL_UINT8(1, ds18b20_test_get_scan_mode());
+
+    /* IDLE -> CONVERT */
+    mock_tim1.SR |= TIM_SR_UIF;
+    ds18b20_poll();
+    TEST_ASSERT_EQUAL_UINT8(DS18B20_ST_CONVERT, ds18b20_test_get_state());
+    /* CONVERT -> WAIT (broadcast Skip ROM) */
+    ds18b20_test_set_edge(0, 510);
+    ds18b20_test_set_edge(1, 700);
+    mock_tim1.SR |= TIM_SR_UIF;
+    ds18b20_poll();
+    TEST_ASSERT_EQUAL_UINT8(DS18B20_ST_WAIT, ds18b20_test_get_state());
+    /* WAIT -> CONTINUE */
+    mock_tim1.SR |= TIM_SR_UIF;
+    ds18b20_poll();
+    TEST_ASSERT_EQUAL_UINT8(DS18B20_ST_CONTINUE, ds18b20_test_get_state());
+    /* CONTINUE -> REQUEST */
+    ds18b20_test_set_edge(0, 510);
+    ds18b20_test_set_edge(1, 700);
+    mock_tim1.SR |= TIM_SR_UIF;
+    ds18b20_poll();
+    TEST_ASSERT_EQUAL_UINT8(DS18B20_ST_REQUEST, ds18b20_test_get_state());
+    /* REQUEST -> READ */
+    ds18b20_test_set_edge(0, 510);
+    ds18b20_test_set_edge(1, 700);
+    mock_tim1.SR |= TIM_SR_UIF;
+    ds18b20_poll();
+    TEST_ASSERT_EQUAL_UINT8(DS18B20_ST_READ, ds18b20_test_get_state());
+    /* READ -> DECODE */
+    mock_tim1.SR |= TIM_SR_UIF;
+    ds18b20_poll();
+    TEST_ASSERT_EQUAL_UINT8(DS18B20_ST_DECODE, ds18b20_test_get_state());
+
+    /* Feed a valid scratchpad and finish the last (only) device read: the
+     * scan ends at IDLE and keeps the strong pull-up engaged across the pause. */
+    uint8_t sd[9] = {0x64, 0x01, 0x4B, 0x46, 0x7F, 0xFF, 0x08, 0x10, 0};
+    sd[8] = ds18b20_crc8(sd, 8);
+    for (int i = 0; i < 9; i++) {
+        for (int b = 0; b < 8; b++) {
+            ds18b20_test_set_pulse(i * 8 + b, ((sd[i] >> b) & 1u) ? ONE : ZERO);
+        }
+    }
+    uint8_t before = test_spy_complete_count;
+    mock_tim1.SR |= TIM_SR_UIF;
+    ds18b20_poll();
+    TEST_ASSERT_EQUAL_UINT8(DS18B20_ST_IDLE, ds18b20_test_get_state());
+    TEST_ASSERT_TRUE(pu_engaged());
+    TEST_ASSERT_TRUE(test_spy_complete_count > before);
+    ds18b20_set_parasite(0);
+}
+
+/*-------------------------------------------------------------
+ *  Test: a parasite-powered Write Scratchpad (no read, no wait)
+ *  finishes immediately and releases the strong pull-up (the
+ *  txn immediate-finish branch).
+ *----------------------------------------------------------*/
+void test_parasite_alarm_thresholds_release_pullup(void) {
+    test_spy_reset();
+    ds18b20_init();
+    ds18b20_test_reset_ctx();
+    ds18b20_set_parasite(1);
+
+    ds18b20_set_alarm_thresholds(0x1E, 0x00);
+    uint8_t done = 0;
+    for (int i = 0; i < 8 && !done; i++) {
+        ds18b20_test_set_edge(0, 510);
+        ds18b20_test_set_edge(1, 700);
+        mock_tim1.SR |= TIM_SR_UIF;
+        done = ds18b20_set_alarm_thresholds_poll();
+    }
+    TEST_ASSERT_TRUE(done);
+    TEST_ASSERT_EQUAL_UINT8(1, ds18b20_test_get_txn_ok());
+    TEST_ASSERT_FALSE(pu_engaged()); /* pull-up released after immediate finish */
+    ds18b20_set_parasite(0);
+}
+
+/*-------------------------------------------------------------
+ *  Test: a parasite-powered Convert T with no device answering
+ *  presence still engages the strong pull-up before the retry
+ *  pause (issue_command no-presence branch).
+ *----------------------------------------------------------*/
+void test_parasite_convert_no_presence_engages_pullup(void) {
+    test_spy_reset();
+    ds18b20_init();
+    ds18b20_test_reset_ctx();
+    ds18b20_set_parasite(1);
+    ds18b20_test_set_state(DS18B20_ST_CONVERT);
+
+    /* No device answers the presence pulse. */
+    ds18b20_test_set_edge(0, 100);
+    ds18b20_test_set_edge(1, 100);
+    mock_tim1.SR |= TIM_SR_UIF;
+    ds18b20_poll();
+
+    TEST_ASSERT_EQUAL_UINT8(DS18B20_ST_IDLE, ds18b20_test_get_state());
+    TEST_ASSERT_TRUE(pu_engaged());
+    TEST_ASSERT_EQUAL_INT(DS18B20_TEMP_ERROR_NO_SENSOR, test_spy_complete_values[0]);
+    ds18b20_set_parasite(0);
+}
+
 void run_test_parasite(void) {
     TEST_RUN(test_parasite_default_off_cycle_leaves_gpio_alone);
     TEST_RUN(test_parasite_default_off_txn_leaves_gpio_alone);
@@ -501,6 +641,10 @@ void run_test_parasite(void) {
     TEST_RUN(test_parasite_copy_scratchpad_window);
     TEST_RUN(test_parasite_recall_eeprom_window);
     TEST_RUN(test_parasite_setter_normalises_and_init_resets);
+    TEST_RUN(test_parasite_guard_band_tracks_mode);
+    TEST_RUN(test_parasite_scan_engages_pullup_across_pause);
+    TEST_RUN(test_parasite_alarm_thresholds_release_pullup);
+    TEST_RUN(test_parasite_convert_no_presence_engages_pullup);
     TEST_RUN(test_detect_parasite_sets_flag);
     TEST_RUN(test_detect_external_clears_flag);
     TEST_RUN(test_detect_no_presence_leaves_flag);

--- a/tests/test/test_pulse_encoding.c
+++ b/tests/test/test_pulse_encoding.c
@@ -10,8 +10,8 @@
 #include "onewire.h"
 #include "unity.h"
 
-#define ONE_P 5u
-#define ZERO_P 60u
+#define ONE_P ow_one_pulse_us
+#define ZERO_P ow_zero_pulse_us
 
 void test_pulse_encoding_zero_byte_all_zero_pulse(void) {
     uint8_t out[8];
@@ -94,12 +94,12 @@ void test_pulse_encoding_single_bit_positions(void) {
 
 void test_onewire_bit_from_pulse_short_is_one(void) {
     TEST_ASSERT_EQUAL_UINT8(1, onewire_bit_from_pulse(0));
-    TEST_ASSERT_EQUAL_UINT8(1, onewire_bit_from_pulse(ONEWIRE_SHORT_PULSE_MAX));
+    TEST_ASSERT_EQUAL_UINT8(1, onewire_bit_from_pulse(ow_short_pulse_max_us));
     TEST_ASSERT_EQUAL_UINT8(1, onewire_bit_from_pulse(5));
 }
 
 void test_onewire_bit_from_pulse_long_is_zero(void) {
-    TEST_ASSERT_EQUAL_UINT8(0, onewire_bit_from_pulse(ONEWIRE_SHORT_PULSE_MAX + 1));
+    TEST_ASSERT_EQUAL_UINT8(0, onewire_bit_from_pulse(ow_short_pulse_max_us + 1));
     TEST_ASSERT_EQUAL_UINT8(0, onewire_bit_from_pulse(60));
     TEST_ASSERT_EQUAL_UINT8(0, onewire_bit_from_pulse(0xFFFF));
 }
@@ -107,7 +107,7 @@ void test_onewire_bit_from_pulse_long_is_zero(void) {
 void test_onewire_decode_pulses_all_short_is_0xFF(void) {
     uint8_t pulse[8];
     for (int i = 0; i < 8; i++)
-        pulse[i] = (uint8_t)ONEWIRE_SHORT_PULSE_MAX;
+        pulse[i] = (uint8_t)ow_short_pulse_max_us;
     uint8_t dst[1];
     onewire_decode_pulses(dst, pulse, 1);
     TEST_ASSERT_EQUAL_UINT8(0xFF, dst[0]);
@@ -125,7 +125,7 @@ void test_onewire_decode_pulses_all_long_is_0x00(void) {
 void test_onewire_decode_pulses_pattern(void) {
     uint8_t pulse[8];
     for (int i = 0; i < 8; i++) {
-        pulse[i] = (uint8_t)(((0x55u >> i) & 1u) ? ONEWIRE_SHORT_PULSE_MAX : 60u);
+        pulse[i] = (uint8_t)(((0x55u >> i) & 1u) ? ow_short_pulse_max_us : 60u);
     }
     uint8_t dst[1];
     onewire_decode_pulses(dst, pulse, 1);
@@ -136,7 +136,7 @@ void test_onewire_decode_pulses_two_bytes(void) {
     uint8_t pulse[16];
     for (int i = 0; i < 16; i++) {
         uint8_t byte = (i < 8) ? 0x55u : 0xAAu;
-        pulse[i] = (uint8_t)(((byte >> (i % 8)) & 1u) ? ONEWIRE_SHORT_PULSE_MAX : 60u);
+        pulse[i] = (uint8_t)(((byte >> (i % 8)) & 1u) ? ow_short_pulse_max_us : 60u);
     }
     uint8_t dst[2];
     onewire_decode_pulses(dst, pulse, 2);

--- a/tests/test/test_read_rom.c
+++ b/tests/test/test_read_rom.c
@@ -17,8 +17,9 @@
 #include "unity.h"
 #include <string.h>
 
-#define ONE 5u
-#define ZERO 60u
+#include "onewire.h"
+#define ONE ow_one_pulse_us
+#define ZERO ow_zero_pulse_us
 
 /*-------------------------------------------------------------
  *  Shared helpers

--- a/tests/test/test_resolution.c
+++ b/tests/test/test_resolution.c
@@ -19,8 +19,9 @@
 #include "unity.h"
 #include <string.h>
 
-#define ONE 5u
-#define ZERO 60u
+#include "onewire.h"
+#define ONE ow_one_pulse_us
+#define ZERO ow_zero_pulse_us
 
 /*-------------------------------------------------------------
  *  Shared helpers

--- a/tests/test/test_rom_addressing.c
+++ b/tests/test/test_rom_addressing.c
@@ -8,10 +8,11 @@
 
 #include "ds18b20.h"
 #include "ds18b20_test_access.h"
+#include "onewire.h"
 #include "unity.h"
 
-#define ONE_P 5u
-#define ZERO_P 60u
+#define ONE_P ow_one_pulse_us
+#define ZERO_P ow_zero_pulse_us
 
 /* Mirror of the driver-internal DS18B20_MATCH_SLOTS so bounds tests use the
  * real slot count (= (DS18B20_ROM_BYTES + 2) * 8 = 80) rather than a literal. */
@@ -53,9 +54,9 @@ void test_rom_addressing_prefix_includes_rom(void) {
     ds18b20_select(rom);
 
     /* ROM byte 0 (0x28 = 00101000, LSB first: 0,0,0,1,0,1,0,0) at slots 8-15 */
-    uint8_t exp[8] = {ZERO_P, ZERO_P, ZERO_P, ONE_P, ZERO_P, ONE_P, ZERO_P, ZERO_P};
     for (int i = 0; i < 8; i++) {
-        TEST_ASSERT_EQUAL_UINT8(exp[i], ds18b20_test_get_addr_cmd((uint8_t)(8 + i)));
+        uint8_t expected = ((0x28u >> i) & 1u) ? (uint8_t)ONE_P : (uint8_t)ZERO_P;
+        TEST_ASSERT_EQUAL_UINT8(expected, ds18b20_test_get_addr_cmd((uint8_t)(8 + i)));
     }
 }
 
@@ -65,9 +66,9 @@ void test_rom_addressing_cmd_overwrites_last_8_slots(void) {
     ds18b20_test_build_addr_cmd(DS18B20_CONVERT_T); /* 0x44 */
 
     /* 0x44 = 01000100, LSB first: 0,0,1,0,0,0,1,0 at slots 72-79 */
-    uint8_t exp[8] = {ZERO_P, ZERO_P, ONE_P, ZERO_P, ZERO_P, ZERO_P, ONE_P, ZERO_P};
     for (int i = 0; i < 8; i++) {
-        TEST_ASSERT_EQUAL_UINT8(exp[i], ds18b20_test_get_addr_cmd((uint8_t)(72 + i)));
+        uint8_t expected = ((0x44u >> i) & 1u) ? (uint8_t)ONE_P : (uint8_t)ZERO_P;
+        TEST_ASSERT_EQUAL_UINT8(expected, ds18b20_test_get_addr_cmd((uint8_t)(72 + i)));
     }
 }
 
@@ -93,9 +94,9 @@ void test_rom_addressing_read_scratchpad_encoding(void) {
     ds18b20_test_build_addr_cmd(DS18B20_READ_SCRATCHPAD); /* 0xBE */
 
     /* 0xBE = 10111110, LSB first: 0,1,1,1,1,1,0,1 at slots 72-79 */
-    uint8_t exp[8] = {ZERO_P, ONE_P, ONE_P, ONE_P, ONE_P, ONE_P, ZERO_P, ONE_P};
     for (int i = 0; i < 8; i++) {
-        TEST_ASSERT_EQUAL_UINT8(exp[i], ds18b20_test_get_addr_cmd((uint8_t)(72 + i)));
+        uint8_t expected = ((0xBEu >> i) & 1u) ? (uint8_t)ONE_P : (uint8_t)ZERO_P;
+        TEST_ASSERT_EQUAL_UINT8(expected, ds18b20_test_get_addr_cmd((uint8_t)(72 + i)));
     }
 }
 

--- a/tests/test/test_search.c
+++ b/tests/test/test_search.c
@@ -16,8 +16,9 @@
 #include "unity.h"
 #include <string.h>
 
-#define ONE 5u
-#define ZERO 60u
+#include "onewire.h"
+#define ONE ow_one_pulse_us
+#define ZERO ow_zero_pulse_us
 
 static uint8_t g_rom[8];
 static uint8_t g_rom_b[8];

--- a/tests/test/test_state_machine.c
+++ b/tests/test/test_state_machine.c
@@ -13,6 +13,7 @@
 #include "ds18b20_test_access.h"
 #include "ds18b20_test_spy.h"
 #include "hw_model.h"
+#include "onewire.h"
 #include "mock_target.h"
 #include "unity.h"
 #include <string.h>
@@ -536,8 +537,8 @@ void test_state_machine_decode_wrong_byte5_reports_error(void) {
  *  E2E: bus search finds one device, select it (Match ROM),
  *  then run the full measurement cycle and get a temperature.
  * -----------------------------------------------------------*/
-#define E2E_ONE 5u
-#define E2E_ZERO 60u
+#define E2E_ONE ow_one_pulse_us
+#define E2E_ZERO ow_zero_pulse_us
 
 static uint8_t g_e2e_rom[8];
 static uint8_t g_e2e_wr_bit;

--- a/tests/test/test_timing.c
+++ b/tests/test/test_timing.c
@@ -29,16 +29,17 @@ void test_timing_command_programs_slot_period(void) {
     hw_reset_all();
     uint8_t cmd[17];
     for (int i = 0; i < 16; i++) {
-        cmd[i] = (i & 1) ? (uint8_t)5 : (uint8_t)60;
+        cmd[i] = (i & 1) ? ow_one_pulse_us : ow_zero_pulse_us;
     }
     cmd[16] = 0;
     test_bus_send_command_n(cmd, 16);
-    /* ARR = ONE_PULSE + ZERO_PULSE + GUARD_BAND = 5+60+5 = 70µs */
-    TEST_ASSERT_EQUAL_UINT16(70, (uint16_t)mock_tim1.ARR);
+    /* ARR = one_pulse + zero_pulse + guard_band (active timing profile) */
+    TEST_ASSERT_EQUAL_UINT16((uint16_t)(ow_one_pulse_us + ow_zero_pulse_us + ow_guard_band_us),
+                             (uint16_t)mock_tim1.ARR);
     /* RCR = slots - 1 */
     TEST_ASSERT_EQUAL_UINT32(15, mock_tim1.RCR);
-    /* the slot-end marker compare triggers the DMA reload at ONE_PULSE + ZERO_PULSE = 65µs */
-    TEST_ASSERT_EQUAL_UINT32(65, MOCK_TIM_MARKER_CCR);
+    /* the slot-end marker compare triggers the DMA reload at one_pulse + zero_pulse */
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)(ow_one_pulse_us + ow_zero_pulse_us), MOCK_TIM_MARKER_CCR);
 }
 
 void test_timing_read_programs_72_slots(void) {
@@ -46,7 +47,8 @@ void test_timing_read_programs_72_slots(void) {
     test_bus_read_data();
     /* 72 data slots: RCR = 71 */
     TEST_ASSERT_EQUAL_UINT32(71, mock_tim1.RCR);
-    TEST_ASSERT_EQUAL_UINT16(70, (uint16_t)mock_tim1.ARR);
+    TEST_ASSERT_EQUAL_UINT16((uint16_t)(ow_one_pulse_us + ow_zero_pulse_us + ow_guard_band_us),
+                             (uint16_t)mock_tim1.ARR);
     /* capture ops preload the output CCR with 0 via OCxPE (hardware bus release) */
     TEST_ASSERT_TRUE(MOCK_TIM_OUT_CCMR & MOCK_TIM_OUT_PE);
     TEST_ASSERT_EQUAL_UINT32(0, MOCK_TIM_OUT_CCR);
@@ -107,6 +109,55 @@ void test_apb_prescaler_div1_for_tim1(void) {
 #endif
 }
 
+/*-------------------------------------------------------------
+ *  Test: onewire timing-profile API
+ *  - invalid profile argument is ignored (no profile switch)
+ *  - set/get round-trips the selected profile's pulse/guard values
+ *----------------------------------------------------------*/
+void test_timing_profile_invalid_arg_ignored(void) {
+    onewire_timing_profile_t saved = onewire_get_timing_profile();
+
+    onewire_set_timing_profile(ONEWIRE_TIMING_COUNT); /* out of range */
+    TEST_ASSERT_EQUAL_INT(saved, onewire_get_timing_profile());
+    onewire_set_timing_profile((onewire_timing_profile_t)0xFF);
+    TEST_ASSERT_EQUAL_INT(saved, onewire_get_timing_profile());
+
+    onewire_set_timing_profile(saved);
+}
+
+void test_timing_profile_set_and_get_roundtrip(void) {
+    onewire_timing_profile_t saved = onewire_get_timing_profile();
+
+    onewire_set_timing_profile(ONEWIRE_TIMING_SLOW);
+    TEST_ASSERT_EQUAL_INT(ONEWIRE_TIMING_SLOW, onewire_get_timing_profile());
+    TEST_ASSERT_EQUAL_UINT8(8, ow_one_pulse_us);
+    TEST_ASSERT_EQUAL_UINT8(90, ow_zero_pulse_us);
+    TEST_ASSERT_EQUAL_UINT8(20, ow_guard_band_us);
+
+    onewire_set_timing_profile(ONEWIRE_TIMING_ROBUST);
+    TEST_ASSERT_EQUAL_UINT8(10, ow_one_pulse_us);
+    TEST_ASSERT_EQUAL_UINT8(110, ow_zero_pulse_us);
+
+    onewire_set_timing_profile(ONEWIRE_TIMING_FAST);
+    TEST_ASSERT_EQUAL_UINT8(5, ow_one_pulse_us);
+    TEST_ASSERT_EQUAL_UINT8(60, ow_zero_pulse_us);
+
+    onewire_set_timing_profile(saved);
+}
+
+/*-------------------------------------------------------------
+ *  Test: a search already owning the timer ignores a re-entrant
+ *  onewire_search_start() (onewire.c early-return guard).
+ *----------------------------------------------------------*/
+void test_search_start_ignored_while_running(void) {
+    onewire_search_start(NULL, 1, DS18B20_SEARCH_ROM, 0);
+    TEST_ASSERT_TRUE(onewire_search_active());
+    /* Second start while the search owns the timer must be ignored. */
+    onewire_search_start(NULL, 1, DS18B20_SEARCH_ROM, 0);
+    TEST_ASSERT_TRUE(onewire_search_active());
+    ds18b20_test_reset_search();
+}
+
 void run_test_timing(void) {
     TEST_RUN(test_timing_reset_programs_timeout_and_pulse);
     TEST_RUN(test_timing_command_programs_slot_period);
@@ -115,4 +166,7 @@ void run_test_timing(void) {
     TEST_RUN(test_timing_start_cycle_pause_5s);
     TEST_RUN(test_timing_temperature_formula);
     TEST_RUN(test_apb_prescaler_div1_for_tim1);
+    TEST_RUN(test_timing_profile_invalid_arg_ignored);
+    TEST_RUN(test_timing_profile_set_and_get_roundtrip);
+    TEST_RUN(test_search_start_ignored_while_running);
 }


### PR DESCRIPTION
## Description

<!-- What does this pull request change, and why? -->

## Related issue

<!-- Link to the issue this PR resolves, if any (e.g. #12). -->

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Build system / tooling
- [x] Documentation
- [x] Other (please describe)

## Design goals check

- [x] The driver remains non-blocking (no `delay_us()` / busy-wait)
- [x] The driver remains interrupt-free (no NVIC usage)
- [x] Register-level access only — no HAL/LL introduced
- [x] Code follows `.clang-format` style

## Verification

- [x] `make` builds cleanly (release, `-Werror`)
- [x] `make SYSCLK_MHZ=8` builds cleanly
- [x] `clang-format --dry-run --Werror` passes on changed files
- [x] `cppcheck` passes
- [x] README and CHANGELOG updated if behavior/usage changed

## Hardware testing

<!-- Describe what was tested and on what hardware (optional but appreciated). -->
