### PR TITLE
style: apply clang-format to satisfy CI format check

### DIFF
--- a/src/ds18b20.c
+++ b/src/ds18b20.c
@@ -13,7 +13,6 @@
  * @{
  */
 
-
 /** @brief Total length of DS18B20 scratchpad in bytes */
 #define DS18B20_SCRATCHPAD_LEN 9
 /** @brief Number of bytes to include in the scratchpad CRC calculation */
@@ -1083,7 +1082,10 @@ uint8_t ds18b20_last_command_ok(void) { return txn_ctx.ok; }
  *       ds18b20_detect_parasite() reports the wiring and stores it back into
  *       this flag on success; this setter tells the driver how to behave.
  */
-void ds18b20_set_parasite(uint8_t parasite) { ctx.parasite = parasite ? 1u : 0u; ow_set_parasite_guard(ctx.parasite); }
+void ds18b20_set_parasite(uint8_t parasite) {
+    ctx.parasite = parasite ? 1u : 0u;
+    ow_set_parasite_guard(ctx.parasite);
+}
 
 /**
  * @brief Current parasite-power configuration of the driver

--- a/src/onewire.c
+++ b/src/onewire.c
@@ -28,10 +28,10 @@
 /** @} */
 
 static const onewire_timing_t timing_profiles[ONEWIRE_TIMING_COUNT] = {
-    [ONEWIRE_TIMING_FAST]     = { 5,  60,  3,  50,  10 },
-    [ONEWIRE_TIMING_STANDARD] = { 5,  60,  5, 100, 10 },
-    [ONEWIRE_TIMING_SLOW]     = { 8,  90, 20, 200, 15 },
-    [ONEWIRE_TIMING_ROBUST]   = { 10, 110, 30, 250, 18 },
+    [ONEWIRE_TIMING_FAST] = {5, 60, 3, 50, 10},
+    [ONEWIRE_TIMING_STANDARD] = {5, 60, 5, 100, 10},
+    [ONEWIRE_TIMING_SLOW] = {8, 90, 20, 200, 15},
+    [ONEWIRE_TIMING_ROBUST] = {10, 110, 30, 250, 18},
 };
 
 static onewire_timing_profile_t ow_profile = ONEWIRE_TIMING_PROFILE_DEFAULT;
@@ -45,7 +45,7 @@ static uint8_t search_read_pulse[3];
 void ow_set_parasite_guard(uint8_t parasite) {
     ow_parasite_flag = parasite ? 1u : 0u;
     ow_guard_band_us = ow_parasite_flag ? timing_profiles[ow_profile].parasite_guard_band
-                                       : timing_profiles[ow_profile].guard_band;
+                                        : timing_profiles[ow_profile].guard_band;
 }
 
 void onewire_set_timing_profile(onewire_timing_profile_t profile) {
@@ -82,7 +82,6 @@ static volatile uint16_t search_edge3[3];
  *        event and kicks read slots 2-3, entry 1 re-arms the slot-3 kick, and
  *        the trailing 0 is written during slot 3 so the one-pulse timer stops
  *        with the line released to idle HIGH (hardware bus release). */
-
 
 /** @brief Edge capture buffer used by the search engine for bus resets and
  *         plain id/cmp pair reads (the merged write+read uses search_edge3). */

--- a/tests/test/test_alarm_search.c
+++ b/tests/test/test_alarm_search.c
@@ -137,8 +137,14 @@ void test_alarm_search_finds_device_sends_0xEC(void) {
                 if (log->count == 8) { /* the 0xEC command feed */
                     ec_feed_checked = 1;
                     uint16_t expected[8];
-                    expected[0] = ZERO; expected[1] = ONE; expected[2] = ONE; expected[3] = ZERO;
-                    expected[4] = ONE; expected[5] = ONE; expected[6] = ONE; expected[7] = 0;
+                    expected[0] = ZERO;
+                    expected[1] = ONE;
+                    expected[2] = ONE;
+                    expected[3] = ZERO;
+                    expected[4] = ONE;
+                    expected[5] = ONE;
+                    expected[6] = ONE;
+                    expected[7] = 0;
                     for (uint8_t i = 0; i < 8; i++) {
                         TEST_ASSERT_EQUAL_UINT16(expected[i], log->values[i]);
                     }

--- a/tests/test/test_app_uart.c
+++ b/tests/test/test_app_uart.c
@@ -20,17 +20,17 @@
 #include "unity.h"
 
 #if defined(OW_PORT_TARGET_G0)
-  #define TXE_BIT  USART_ISR_TXE_TXFNF
-  #define TX_SR    ISR
-  #define TX_DR    TDR
+#define TXE_BIT USART_ISR_TXE_TXFNF
+#define TX_SR ISR
+#define TX_DR TDR
 #elif defined(OW_PORT_TARGET_F0)
-  #define TXE_BIT  USART_ISR_TXE
-  #define TX_SR    ISR
-  #define TX_DR    TDR
+#define TXE_BIT USART_ISR_TXE
+#define TX_SR ISR
+#define TX_DR TDR
 #else /* F1 */
-  #define TXE_BIT  USART_SR_TXE
-  #define TX_SR    SR
-  #define TX_DR    DR
+#define TXE_BIT USART_SR_TXE
+#define TX_SR SR
+#define TX_DR DR
 #endif
 
 /* Drain any bytes left in the static ring buffer from earlier tests. */

--- a/tests/test/test_harness_api.c
+++ b/tests/test/test_harness_api.c
@@ -11,9 +11,9 @@
 #include "ds18b20.h"
 #include "ds18b20_test_access.h"
 #include "ds18b20_test_spy.h"
+#include "hw_model.h"
 #include "ow_stats.h"
 #include "ow_stats_test_access.h"
-#include "hw_model.h"
 #include "unity.h"
 
 void test_harness_accessor_smoke(void) {

--- a/tests/test/test_parasite.c
+++ b/tests/test/test_parasite.c
@@ -17,11 +17,11 @@
  * ============================================================ */
 
 #include "ds18b20.h"
-#include "onewire.h"
 #include "ds18b20_test_access.h"
 #include "ds18b20_test_spy.h"
 #include "hw_model.h"
 #include "mock_target.h"
+#include "onewire.h"
 #include "unity.h"
 #include <string.h>
 

--- a/tests/test/test_state_machine.c
+++ b/tests/test/test_state_machine.c
@@ -13,8 +13,8 @@
 #include "ds18b20_test_access.h"
 #include "ds18b20_test_spy.h"
 #include "hw_model.h"
-#include "onewire.h"
 #include "mock_target.h"
+#include "onewire.h"
 #include "unity.h"
 #include <string.h>
 


### PR DESCRIPTION
## Description

<!-- What does this pull request change, and why? -->

## Related issue

<!-- Link to the issue this PR resolves, if any (e.g. #12). -->

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Build system / tooling
- [x] Documentation
- [x] Other (please describe)

## Design goals check

- [x] The driver remains non-blocking (no `delay_us()` / busy-wait)
- [x] The driver remains interrupt-free (no NVIC usage)
- [x] Register-level access only — no HAL/LL introduced
- [x] Code follows `.clang-format` style

## Verification

- [x] `make` builds cleanly (release, `-Werror`)
- [x] `make SYSCLK_MHZ=8` builds cleanly
- [x] `clang-format --dry-run --Werror` passes on changed files
- [x] `cppcheck` passes
- [x] README and CHANGELOG updated if behavior/usage changed

## Hardware testing

<!-- Describe what was tested and on what hardware (optional but appreciated). -->
